### PR TITLE
[PLA-2087] Panics main thread on subscription panic

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 pub use importer::write_seed;
 pub use multitenant::set_multitenant;
 pub use platform_client::{set_wallet_account, update_transaction};
-pub use subscription::SubscriptionParams;
+pub use subscription::{SubscriptionJob, SubscriptionParams};
 pub use transaction::TransactionJob;
 pub use wallet::DeriveWalletJob;
 

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -1,8 +1,64 @@
 use std::sync::{Arc, Mutex};
+use std::{panic, process};
 use subxt::client::ClientRuntimeUpdater;
 use subxt::ext::subxt_core;
 use subxt::{OnlineClient, PolkadotConfig};
 use subxt_core::config::substrate;
+
+#[derive(Debug)]
+pub struct SubscriptionJob {
+    params: Arc<SubscriptionParams>,
+}
+
+impl SubscriptionJob {
+    pub fn new(params: Arc<SubscriptionParams>) -> Self {
+        Self { params }
+    }
+
+    pub fn create_job(rpc: Arc<OnlineClient<PolkadotConfig>>) -> SubscriptionJob {
+        let block_header = Arc::new(Mutex::new(None));
+        let spec_version = Arc::new(Mutex::new(None));
+        let subscription = Arc::new(SubscriptionParams {
+            rpc,
+            block_header: Arc::clone(&block_header),
+            spec_version: Arc::clone(&spec_version),
+        });
+
+        SubscriptionJob::new(subscription)
+    }
+
+    pub fn start(&self) {
+        let orig_hook = panic::take_hook();
+        panic::set_hook(Box::new(move |panic_info| {
+            orig_hook(panic_info);
+            process::exit(1);
+        }));
+
+        self.start_block();
+        self.start_runtime();
+    }
+
+    pub fn start_block(&self) {
+        let block_sub = Arc::clone(&self.params);
+
+        tokio::spawn(async move {
+            block_sub.block_subscription().await;
+        });
+    }
+
+    pub fn start_runtime(&self) {
+        let runtime_sub = Arc::clone(&self.params);
+        let updater = runtime_sub.rpc.updater();
+
+        tokio::spawn(async move {
+            runtime_sub.runtime_subscription(updater).await;
+        });
+    }
+
+    pub fn get_params(&self) -> Arc<SubscriptionParams> {
+        Arc::clone(&self.params)
+    }
+}
 
 #[derive(Debug)]
 pub struct SubscriptionParams {
@@ -12,30 +68,6 @@ pub struct SubscriptionParams {
 }
 
 impl SubscriptionParams {
-    pub fn new(rpc: Arc<OnlineClient<PolkadotConfig>>) -> Arc<Self> {
-        let block_header = Arc::new(Mutex::new(None));
-        let spec_version = Arc::new(Mutex::new(None));
-
-        let subscription = Arc::new(Self {
-            rpc: Arc::clone(&rpc),
-            block_header: Arc::clone(&block_header),
-            spec_version: Arc::clone(&spec_version),
-        });
-
-        let block_sub = Arc::clone(&subscription);
-        tokio::spawn(async move {
-            block_sub.block_subscription().await;
-        });
-
-        let runtime_sub = Arc::clone(&subscription);
-        let updater = runtime_sub.rpc.updater();
-        tokio::spawn(async move {
-            runtime_sub.runtime_subscription(updater).await;
-        });
-
-        subscription
-    }
-
     async fn runtime_subscription(self: Arc<Self>, updater: ClientRuntimeUpdater<PolkadotConfig>) {
         let mut update_stream = updater.runtime_updates().await.unwrap();
 


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Introduced `SubscriptionJob` struct to manage subscription tasks, replacing the previous `SubscriptionParams`.
- Added methods in `SubscriptionJob` to start block and runtime subscriptions, enhancing the subscription handling mechanism.
- Integrated `SubscriptionJob` in the main function, replacing `SubscriptionParams` and starting the job.
- Implemented a panic hook in `SubscriptionJob` to exit the process on panic, improving error handling.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lib.rs</strong><dd><code>Export `SubscriptionJob` in library module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/lib.rs

- Added `SubscriptionJob` to the list of public exports.



</details>


  </td>
  <td><a href="https://github.com/enjin/wallet-daemon/pull/67/files#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main.rs</strong><dd><code>Integrate `SubscriptionJob` in main function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main.rs

<li>Replaced <code>SubscriptionParams</code> with <code>SubscriptionJob</code>.<br> <li> Initialized and started <code>SubscriptionJob</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/enjin/wallet-daemon/pull/67/files#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fc">+5/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>subscription.rs</strong><dd><code>Implement `SubscriptionJob` for managing subscriptions</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/subscription.rs

<li>Introduced <code>SubscriptionJob</code> struct to manage subscription tasks.<br> <li> Added methods to start block and runtime subscriptions.<br> <li> Implemented panic hook to exit process on panic.<br>


</details>


  </td>
  <td><a href="https://github.com/enjin/wallet-daemon/pull/67/files#diff-38897eb79b53e70cde8f4323479b885b0b59fbefa52dbf53c4e8e639ccde3df3">+44/-12</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information