### PR TITLE
PLA-2389: Fix seed path handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ store
 docker-compose.*.yml
 /config.local.json
 .env
+wallet.seed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5106,7 +5106,7 @@ dependencies = [
 
 [[package]]
 name = "wallet-daemon"
-version = "3.0.2"
+version = "3.0.3"
 dependencies = [
  "aes-gcm",
  "argon2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wallet-daemon"
-version = "3.0.2"
+version = "3.0.3"
 edition = "2024"
 
 [[bin]]

--- a/src/importer.rs
+++ b/src/importer.rs
@@ -3,7 +3,7 @@ use sp_core::crypto::{Ss58AddressFormat, Ss58Codec};
 use std::path::Path;
 
 pub fn write_seed(seed: String, seed_path: &Path, key_pass: &str) -> std::io::Result<()> {
-    let (_, keypair_tx) = write_mnemonic(seed_path, key_pass, Some(&seed));
+    let (_, keypair_tx) = write_mnemonic(seed_path, key_pass, Some(&seed), false);
 
     let public_key = keypair_tx.public_key().0;
     let account_id = sp_core::crypto::AccountId32::from(public_key);
@@ -53,8 +53,8 @@ mod tests {
 
         write_seed(mnemonic.to_string(), temp_dir.path(), key_pass).unwrap();
 
-        let seed_path = temp_dir.path().to_str().unwrap();
-        let loaded_keypair = load_seed(seed_path, key_pass, true);
+        let seed_path = temp_dir.path().to_path_buf();
+        let loaded_keypair = load_seed(seed_path.clone(), key_pass, true);
         let reloaded_keypair = load_seed(seed_path, key_pass, false);
 
         assert_eq!(
@@ -73,7 +73,7 @@ mod tests {
 
         write_seed(mnemonic.to_string(), temp_dir.path(), key_pass).unwrap();
 
-        let seed_path = temp_dir.path().to_str().unwrap();
+        let seed_path = temp_dir.path().to_path_buf();
         let result = std::panic::catch_unwind(|| load_seed(seed_path, wrong_pass, false));
         assert!(result.is_err(), "wrong password should panic");
     }
@@ -86,7 +86,7 @@ mod tests {
 
         write_seed(mnemonic.to_string(), temp_dir.path(), key_pass).unwrap();
 
-        let keypair = load_seed(temp_dir.path().to_str().unwrap(), key_pass, false);
+        let keypair = load_seed(temp_dir.path().to_path_buf(), key_pass, false);
         let public_key = keypair.public_key().0;
         let account_id = sp_core::crypto::AccountId32::from(public_key);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,7 +38,14 @@ mod wallet_loader;
 
 #[tokio::main(flavor = "multi_thread")]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let seed_path = dotenvy::var("SEED_PATH").unwrap_or("store".to_string());
+    let seed_path = dotenvy::var("SEED_PATH").unwrap_or_else(|_| {
+        let cwd = env::current_dir().expect("Failed to get current directory");
+        if cwd.join("store").is_dir() {
+            "store".to_string()
+        } else {
+            cwd.to_string_lossy().to_string()
+        }
+    });
 
     // check for subcommands
     match Cli::parse().command {

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,6 +44,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             println!("Enjin Platform - Import Wallet");
             if seed_path.is_file() && seed_path.exists() {
                 panic!("importing wallet would overwrite existing file at {seed_path:?}");
+                // TODO: it can also panic if it's a directory. Consider refactoring to also allow
+                // panicking here in that case. Currently, it will panic after password is entered.
             }
             let key_pass = dotenvy::var("KEY_PASS").expect("KEY_PASS env var is required");
             let seed = rpassword::prompt_password("Please type your 12-word mnemonic: ").unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,13 +5,11 @@ use crate::substrate_client::EnjinConfig;
 use crate::transaction::TransactionJob;
 use crate::types::{Cli, Commands};
 use crate::wallet::DeriveWalletJob;
-use crate::wallet_loader::load_seed;
+use crate::wallet_loader::{load_seed, resolve_seed_path};
 use clap::Parser;
 use reqwest::header::HeaderMap;
 use std::env;
-use std::path::PathBuf;
 use std::process::exit;
-use std::str::FromStr;
 use subxt::OfflineClient;
 use tracing_subscriber::EnvFilter;
 use tracing_subscriber::util::SubscriberInitExt;
@@ -38,16 +36,8 @@ mod wallet_loader;
 
 #[tokio::main(flavor = "multi_thread")]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let seed_path = dotenvy::var("SEED_PATH").unwrap_or_else(|_| {
-        let cwd = env::current_dir().expect("Failed to get current directory");
-        if cwd.join("wallet.seed").is_file() {
-            cwd.to_string_lossy().to_string()
-        } else if cwd.join("store").is_dir() {
-            "store".to_string()
-        } else {
-            cwd.to_string_lossy().to_string()
-        }
-    });
+    let seed_path_buf = resolve_seed_path(dotenvy::var("SEED_PATH").ok().as_deref());
+    let seed_path = seed_path_buf.to_string_lossy().to_string();
 
     // check for subcommands
     match Cli::parse().command {
@@ -55,8 +45,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             println!("Enjin Platform - Import Wallet");
             let key_pass = dotenvy::var("KEY_PASS").expect("KEY_PASS env var is required");
             let seed = rpassword::prompt_password("Please type your 12-word mnemonic: ").unwrap();
-            let seed_path = PathBuf::from_str(&seed_path).expect("SEED_PATH must be a valid path");
-            importer::write_seed(seed, &seed_path, &key_pass)
+            importer::write_seed(seed, &seed_path_buf, &key_pass)
                 .expect("Failed to import your wallet");
 
             exit(0);

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,7 +40,9 @@ mod wallet_loader;
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let seed_path = dotenvy::var("SEED_PATH").unwrap_or_else(|_| {
         let cwd = env::current_dir().expect("Failed to get current directory");
-        if cwd.join("store").is_dir() {
+        if cwd.join("wallet.seed").is_file() {
+            cwd.to_string_lossy().to_string()
+        } else if cwd.join("store").is_dir() {
             "store".to_string()
         } else {
             cwd.to_string_lossy().to_string()

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,23 +36,25 @@ mod wallet_loader;
 
 #[tokio::main(flavor = "multi_thread")]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let seed_path_buf = resolve_seed_path(dotenvy::var("SEED_PATH").ok().as_deref());
-    let seed_path = seed_path_buf.to_string_lossy().to_string();
+    let seed_path = resolve_seed_path(dotenvy::var("SEED_PATH").ok().as_deref());
 
     // check for subcommands
     match Cli::parse().command {
         Some(Commands::Import) => {
             println!("Enjin Platform - Import Wallet");
+            if seed_path.is_file() && seed_path.exists() {
+                panic!("importing wallet would overwrite existing file at {seed_path:?}");
+            }
             let key_pass = dotenvy::var("KEY_PASS").expect("KEY_PASS env var is required");
             let seed = rpassword::prompt_password("Please type your 12-word mnemonic: ").unwrap();
-            importer::write_seed(seed, &seed_path_buf, &key_pass)
+            importer::write_seed(seed, &seed_path, &key_pass)
                 .expect("Failed to import your wallet");
 
             exit(0);
         }
         Some(Commands::PrintSeed) => {
             let key_pass = dotenvy::var("KEY_PASS").expect("KEY_PASS env var is required");
-            load_seed(&seed_path, &key_pass, true);
+            load_seed(seed_path.clone(), &key_pass, true);
             exit(0);
         }
         None => {
@@ -68,7 +70,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .try_init()?;
 
     let key_pass = dotenvy::var("KEY_PASS").expect("KEY_PASS env var is required");
-    let keypair = load_seed(&seed_path, &key_pass, false);
+    let keypair = load_seed(seed_path, &key_pass, false);
 
     let platform_url = dotenvy::var("PLATFORM_URL").unwrap_or(DEFAULT_PLATFORM_URL.to_string());
     global::PLATFORM_URL

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -56,8 +56,11 @@ where
                                         .map(|(_k, v)| format!("{v}"))
                                         .collect::<Vec<_>>()
                                         .join(",");
-                                    let msg = e.message;
-                                    format!("{}\n    Extensions: {}", msg, ext_str)
+                                    if !ext_str.is_empty() {
+                                        format!("{}\n    Extensions: {}", &e.message, ext_str)
+                                    } else {
+                                        e.message
+                                    }
                                 } else {
                                     e.message
                                 }

--- a/src/wallet_loader.rs
+++ b/src/wallet_loader.rs
@@ -88,7 +88,7 @@ pub fn load_seed(seed_path: &str, key_pass: &str, print_seed: bool) -> Keypair {
 }
 
 fn get_keys(seed_path: &Path, key_pass: &str, print_seed: bool) -> Keypair {
-    let base_path = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let base_path = env::current_dir().expect("Failed to get current directory");
     let path = if seed_path.is_absolute() {
         seed_path.to_path_buf()
     } else {
@@ -125,7 +125,7 @@ pub fn write_mnemonic(
     key_pass: &str,
     mnemonic: Option<&str>,
 ) -> (String, Keypair) {
-    let base_path = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let base_path = env::current_dir().expect("Failed to get current directory");
     let path = if seed_path.is_absolute() {
         seed_path.to_path_buf()
     } else {

--- a/src/wallet_loader.rs
+++ b/src/wallet_loader.rs
@@ -7,6 +7,30 @@ use subxt_signer::SecretUri;
 use subxt_signer::bip39::Mnemonic;
 use subxt_signer::sr25519::Keypair;
 
+pub fn resolve_seed_path(seed_path: Option<&str>) -> PathBuf {
+    let cwd = env::current_dir().expect("Failed to get current directory");
+
+    match seed_path {
+        Some(path) => {
+            let seed_path = PathBuf::from_str(path).expect("SEED_PATH must be a valid path");
+            if seed_path.is_absolute() {
+                seed_path
+            } else {
+                cwd.join(&seed_path)
+            }
+        }
+        None => {
+            if cwd.join("wallet.seed").is_file() {
+                cwd.join("wallet.seed")
+            } else if cwd.join("store").is_dir() {
+                cwd.join("store")
+            } else {
+                cwd
+            }
+        }
+    }
+}
+
 fn decrypt_mnemonic(content: &str) -> String {
     let stripped = content
         .trim()
@@ -24,9 +48,16 @@ fn decrypt_mnemonic(content: &str) -> String {
 
 pub fn load_seed(seed_path: &str, key_pass: &str, print_seed: bool) -> Keypair {
     let seed_path = PathBuf::from_str(seed_path).expect("SEED_PATH must be a valid path");
-    if !seed_path.exists() {
-        panic!("SEED_PATH does not exist: {:?}", seed_path)
+
+    let print_kind = if print_seed {
+        PrintKind::Seed
+    } else {
+        PrintKind::Normal
     };
+
+    if !seed_path.exists() {
+        return load_wallet(&seed_path, key_pass, print_kind);
+    }
 
     let mut v1_migration_path: Option<PathBuf> = None;
     let seed_dir = if seed_path.is_dir() {
@@ -79,23 +110,11 @@ pub fn load_seed(seed_path: &str, key_pass: &str, print_seed: bool) -> Keypair {
         seed_path = wallet_seed_path;
     }
 
-    let print_kind = if print_seed {
-        PrintKind::Seed
-    } else {
-        PrintKind::Normal
-    };
     load_wallet(&seed_path, key_pass, print_kind)
 }
 
-fn get_keys(seed_path: &Path, key_pass: &str, print_seed: bool) -> Keypair {
-    let base_path = env::current_dir().expect("Failed to get current directory");
-    let path = if seed_path.is_absolute() {
-        seed_path.to_path_buf()
-    } else {
-        base_path.join(seed_path)
-    };
-
-    if path.is_file() {
+fn get_keys(path: &Path, key_pass: &str, print_seed: bool) -> Keypair {
+       if path.is_file() {
         let content = fs::read_to_string(&path).expect("Unable to read file");
 
         let decrypted = match crypto::decrypt(&content, key_pass) {
@@ -121,17 +140,10 @@ fn get_keys(seed_path: &Path, key_pass: &str, print_seed: bool) -> Keypair {
 }
 
 pub fn write_mnemonic(
-    seed_path: &Path,
+    path: &Path,
     key_pass: &str,
     mnemonic: Option<&str>,
 ) -> (String, Keypair) {
-    let base_path = env::current_dir().expect("Failed to get current directory");
-    let path = if seed_path.is_absolute() {
-        seed_path.to_path_buf()
-    } else {
-        base_path.join(seed_path)
-    };
-
     let mnemonic = match mnemonic {
         Some(m) => m.to_string(),
         None => Mnemonic::generate(12).unwrap().to_string(),
@@ -144,7 +156,7 @@ pub fn write_mnemonic(
     let final_path = if path.is_dir() {
         path.join("wallet.seed")
     } else {
-        path
+        path.to_path_buf()
     };
 
     if let Some(parent) = final_path.parent() {
@@ -268,5 +280,99 @@ mod tests {
             keypair_v1.public_key().0,
             "wallet.seed should load to same key as v1 file"
         );
+    }
+
+    #[test]
+    fn test_resolve_seed_path_directory_with_wallet_seed() {
+        let temp_dir = TempDir::new().unwrap();
+        let key_pass = "test_password";
+        let mnemonic = "muscle wing great bounce arctic guess trim celery budget shock march whale";
+        let encrypted = crypto::encrypt_with_imported(mnemonic, key_pass, true);
+
+        let wallet_seed_path = temp_dir.path().join("wallet.seed");
+        fs::write(&wallet_seed_path, &encrypted).unwrap();
+
+        let result = resolve_seed_path(Some(temp_dir.path().to_str().unwrap()));
+        assert_eq!(result, temp_dir.path());
+    }
+
+    #[test]
+    fn test_resolve_seed_path_directory_with_upgradable_seed() {
+        let temp_dir = TempDir::new().unwrap();
+
+        let pubkey_suffix = "a82a0376985e4bdca417ceebc52499664ac78437e5ae074de72907a1b42b643e";
+        let v1_file_name = format!("73723235{}", pubkey_suffix);
+        let v1_path = temp_dir.path().join(&v1_file_name);
+        let mut v1_file = fs::File::create(&v1_path).unwrap();
+        write!(
+            v1_file,
+            "\"muscle wing great bounce arctic guess trim celery budget shock march whale\""
+        )
+        .unwrap();
+
+        let result = resolve_seed_path(Some(temp_dir.path().to_str().unwrap()));
+        assert_eq!(result, temp_dir.path());
+    }
+
+    #[test]
+    fn test_resolve_seed_path_directory_empty() {
+        let temp_dir = TempDir::new().unwrap();
+
+        let result = resolve_seed_path(Some(temp_dir.path().to_str().unwrap()));
+        assert_eq!(result, temp_dir.path());
+    }
+
+    #[test]
+    fn test_resolve_seed_path_existing_file() {
+        let temp_dir = TempDir::new().unwrap();
+        let key_pass = "test_password";
+        let mnemonic = "muscle wing great bounce arctic guess trim celery budget shock march whale";
+        let encrypted = crypto::encrypt_with_imported(mnemonic, key_pass, true);
+
+        let seed_file = temp_dir.path().join("myseed");
+        fs::write(&seed_file, &encrypted).unwrap();
+
+        let result = resolve_seed_path(Some(temp_dir.path().join("myseed").to_str().unwrap()));
+        assert_eq!(result, seed_file);
+    }
+
+    #[test]
+    fn test_resolve_seed_path_nonexistent() {
+        let temp_dir = TempDir::new().unwrap();
+
+        let none_file = temp_dir.path().join("nonexistent.seed");
+
+        let result = resolve_seed_path(Some(temp_dir.path().join("nonexistent.seed").to_str().unwrap()));
+        assert_eq!(result, none_file);
+    }
+
+    #[test]
+    fn test_resolve_seed_path_default_with_wallet_seed() {
+        let temp_dir = TempDir::new().unwrap();
+        let key_pass = "test_password";
+        let mnemonic = "muscle wing great bounce arctic guess trim celery budget shock march whale";
+        let encrypted = crypto::encrypt_with_imported(mnemonic, key_pass, true);
+
+        let wallet_seed_path = temp_dir.path().join("wallet.seed");
+        fs::write(&wallet_seed_path, &encrypted).unwrap();
+
+        let original_cwd = std::env::current_dir().unwrap();
+        std::env::set_current_dir(&temp_dir).unwrap();
+        let result = resolve_seed_path(None);
+        std::env::set_current_dir(original_cwd).unwrap();
+        assert_eq!(
+            result.clone().canonicalize().unwrap(),
+            wallet_seed_path.clone().canonicalize().unwrap()
+        );
+    }
+
+    #[test]
+    fn test_load_seed_creates_new_if_not_exists() {
+        let temp_dir = TempDir::new().unwrap();
+        let key_pass = "test_password";
+
+        let none_file = temp_dir.path().join("nonexistent.seed");
+        let _result = load_seed(none_file.to_str().unwrap(), key_pass, false);
+        assert!(none_file.exists());
     }
 }

--- a/src/wallet_loader.rs
+++ b/src/wallet_loader.rs
@@ -46,33 +46,23 @@ fn decrypt_mnemonic(content: &str) -> String {
     stripped
 }
 
-pub fn load_seed(seed_path: &str, key_pass: &str, print_seed: bool) -> Keypair {
-    let seed_path = PathBuf::from_str(seed_path).expect("SEED_PATH must be a valid path");
-
+pub fn load_seed(seed_path: PathBuf, key_pass: &str, print_seed: bool) -> Keypair {
     let print_kind = if print_seed {
         PrintKind::Seed
     } else {
         PrintKind::Normal
     };
 
-    if !seed_path.exists() {
+    if !seed_path.exists() || seed_path.is_file() {
         return load_wallet(&seed_path, key_pass, print_kind);
     }
 
     let mut v1_migration_path: Option<PathBuf> = None;
-    let seed_dir = if seed_path.is_dir() {
-        seed_path
-    } else {
-        seed_path
-            .parent()
-            .map(PathBuf::from)
-            .unwrap_or(seed_path.clone())
-    };
-    let mut seed_path = if seed_dir.join("wallet.seed").exists() {
-        seed_dir.join("wallet.seed")
+    let mut seed_path = if seed_path.join("wallet.seed").exists() {
+        seed_path.join("wallet.seed")
     } else {
         let mut backup_seed_path = None;
-        if let Ok(entries) = fs::read_dir(&seed_dir) {
+        if let Ok(entries) = fs::read_dir(&seed_path) {
             for entry in entries.flatten() {
                 if let Some(name) = entry.file_name().to_str()
                     && name.starts_with("73723235")
@@ -86,8 +76,13 @@ pub fn load_seed(seed_path: &str, key_pass: &str, print_seed: bool) -> Keypair {
         if backup_seed_path.is_some() {
             v1_migration_path = backup_seed_path.clone();
         }
-        backup_seed_path.unwrap_or(seed_dir.join("wallet.seed"))
+        backup_seed_path.unwrap_or(seed_path.join("wallet.seed"))
     };
+
+    if !seed_path.exists() {
+        return write_mnemonic(&seed_path, key_pass, None, true).1;
+    }
+
     tracing::debug!("loading seed from path: {}", seed_path.display());
 
     if let Some(v1_path) = v1_migration_path {
@@ -95,11 +90,10 @@ pub fn load_seed(seed_path: &str, key_pass: &str, print_seed: bool) -> Keypair {
         let v1_content = fs::read_to_string(&v1_path).expect("Unable to read v1 file");
         let mnemonic = decrypt_mnemonic(&v1_content);
         let v2_encrypted = crypto::encrypt_with_imported(&mnemonic, key_pass, true);
-        let wallet_seed_path = seed_dir.join("wallet.seed");
+        let wallet_seed_path = v1_path.parent().unwrap().join("wallet.seed");
         fs::write(&wallet_seed_path, &v2_encrypted).expect("Unable to write wallet.seed");
 
         let verified_keypair = load_wallet(&wallet_seed_path, key_pass, PrintKind::Nothing);
-
         let v1_keypair = load_wallet(&v1_path, key_pass, PrintKind::Nothing);
 
         if verified_keypair.public_key().0 != v1_keypair.public_key().0 {
@@ -114,8 +108,8 @@ pub fn load_seed(seed_path: &str, key_pass: &str, print_seed: bool) -> Keypair {
 }
 
 fn get_keys(path: &Path, key_pass: &str, print_seed: bool) -> Keypair {
-       if path.is_file() {
-        let content = fs::read_to_string(&path).expect("Unable to read file");
+    if path.is_file() {
+        let content = fs::read_to_string(path).expect("Unable to read file");
 
         let decrypted = match crypto::decrypt(&content, key_pass) {
             Ok(decrypted) => decrypted,
@@ -132,7 +126,7 @@ fn get_keys(path: &Path, key_pass: &str, print_seed: bool) -> Keypair {
         return Keypair::from_uri(&uri).expect("valid keypair");
     }
 
-    let (mnemonic, keypair) = write_mnemonic(&path, key_pass, None);
+    let (mnemonic, keypair) = write_mnemonic(path, key_pass, None, true);
     if print_seed {
         println!("{}", &mnemonic);
     }
@@ -143,6 +137,7 @@ pub fn write_mnemonic(
     path: &Path,
     key_pass: &str,
     mnemonic: Option<&str>,
+    allow_overwrite: bool,
 ) -> (String, Keypair) {
     let mnemonic = match mnemonic {
         Some(m) => m.to_string(),
@@ -153,7 +148,11 @@ pub fn write_mnemonic(
     let uri = SecretUri::from_str(&mnemonic).expect("valid URI");
     let keypair_tx = Keypair::from_uri(&uri).expect("valid keypair");
 
-    let final_path = if path.is_dir() {
+    let is_directory = path.is_dir();
+    let final_path = if is_directory {
+        path.join("wallet.seed")
+    } else if !path.exists() && path.extension().is_none() {
+        fs::create_dir_all(path).ok();
         path.join("wallet.seed")
     } else {
         path.to_path_buf()
@@ -163,6 +162,9 @@ pub fn write_mnemonic(
         fs::create_dir_all(parent).ok();
     }
 
+    if !allow_overwrite && final_path.is_file() {
+        panic!("file at {final_path:?} already exists");
+    }
     fs::write(&final_path, encrypted_mnemonic).expect("Unable to write file");
 
     (mnemonic, keypair_tx)
@@ -234,8 +236,8 @@ mod tests {
         .unwrap();
         drop(v1_file);
 
-        let seed_path = temp_dir.path().to_str().unwrap();
-        let keypair = load_seed(seed_path, key_pass, false);
+        let seed_path = temp_dir.path().to_path_buf();
+        let keypair = load_seed(seed_path.clone(), key_pass, false);
         let migrated_public_key = keypair.public_key().0;
 
         let wallet_seed_path = temp_dir.path().join("wallet.seed");
@@ -266,7 +268,7 @@ mod tests {
         let wallet_seed_path = temp_dir.path().join("wallet.seed");
         fs::write(&wallet_seed_path, &encrypted).unwrap();
 
-        let seed_path = temp_dir.path().to_str().unwrap();
+        let seed_path = temp_dir.path().to_path_buf();
         let keypair = load_seed(seed_path, key_pass, false);
 
         let v1_path = temp_dir.path().join("73723235test");
@@ -342,7 +344,9 @@ mod tests {
 
         let none_file = temp_dir.path().join("nonexistent.seed");
 
-        let result = resolve_seed_path(Some(temp_dir.path().join("nonexistent.seed").to_str().unwrap()));
+        let result = resolve_seed_path(Some(
+            temp_dir.path().join("nonexistent.seed").to_str().unwrap(),
+        ));
         assert_eq!(result, none_file);
     }
 
@@ -372,7 +376,47 @@ mod tests {
         let key_pass = "test_password";
 
         let none_file = temp_dir.path().join("nonexistent.seed");
-        let _result = load_seed(none_file.to_str().unwrap(), key_pass, false);
-        assert!(none_file.exists());
+        let _result = load_seed(none_file, key_pass, false);
+        assert!(temp_dir.path().join("nonexistent.seed").exists());
+    }
+
+    #[test]
+    fn test_load_seed_specific_file_not_directory() {
+        let temp_dir = TempDir::new().unwrap();
+        let key_pass = "test_password";
+        let mnemonic = "muscle wing great bounce arctic guess trim celery budget shock march whale";
+        let encrypted = crypto::encrypt_with_imported(mnemonic, key_pass, true);
+
+        let wallet_seed_path = temp_dir.path().join("wallet.seed");
+        fs::write(&wallet_seed_path, &encrypted).unwrap();
+
+        let custom_file = temp_dir.path().join("custom.seed");
+        let custom_encrypted = crypto::encrypt_with_imported(mnemonic, key_pass, true);
+        fs::write(&custom_file, &custom_encrypted).unwrap();
+
+        let _result = load_seed(custom_file, key_pass, false);
+
+        assert!(wallet_seed_path.exists());
+        assert!(!fs::read_to_string(&wallet_seed_path).unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_write_mnemonic_creates_nonexistent_directory() {
+        let temp_dir = TempDir::new().unwrap();
+        let key_pass = "test_password";
+
+        let nonexistent_dir = temp_dir.path().join("new_directory_that_does_not_exist");
+        assert!(!nonexistent_dir.exists());
+
+        let (_mnemonic, _keypair) = write_mnemonic(&nonexistent_dir, key_pass, None, false);
+
+        assert!(nonexistent_dir.is_dir(), "Directory should be created");
+        let wallet_seed_path = nonexistent_dir.join("wallet.seed");
+        assert!(
+            wallet_seed_path.exists(),
+            "wallet.seed should be created in the new directory"
+        );
+        let content = fs::read_to_string(&wallet_seed_path).unwrap();
+        assert!(!content.is_empty(), "wallet.seed should not be empty");
     }
 }

--- a/src/wallet_loader.rs
+++ b/src/wallet_loader.rs
@@ -152,14 +152,14 @@ pub fn write_mnemonic(
     let final_path = if is_directory {
         path.join("wallet.seed")
     } else if !path.exists() && path.extension().is_none() {
-        fs::create_dir_all(path).ok();
+        fs::create_dir_all(path).expect("Unable to create seed directory");
         path.join("wallet.seed")
     } else {
         path.to_path_buf()
     };
 
     if let Some(parent) = final_path.parent() {
-        fs::create_dir_all(parent).ok();
+        fs::create_dir_all(parent).expect("Unable to create seed directory");
     }
 
     if !allow_overwrite && final_path.is_file() {
@@ -350,6 +350,24 @@ mod tests {
         assert_eq!(result, none_file);
     }
 
+    struct CwdGuard {
+        original_cwd: PathBuf,
+    }
+
+    impl CwdGuard {
+        fn new() -> Self {
+            Self {
+                original_cwd: std::env::current_dir().unwrap(),
+            }
+        }
+    }
+
+    impl Drop for CwdGuard {
+        fn drop(&mut self) {
+            std::env::set_current_dir(&self.original_cwd).unwrap();
+        }
+    }
+
     #[test]
     fn test_resolve_seed_path_default_with_wallet_seed() {
         let temp_dir = TempDir::new().unwrap();
@@ -360,10 +378,9 @@ mod tests {
         let wallet_seed_path = temp_dir.path().join("wallet.seed");
         fs::write(&wallet_seed_path, &encrypted).unwrap();
 
-        let original_cwd = std::env::current_dir().unwrap();
+        let _guard = CwdGuard::new();
         std::env::set_current_dir(&temp_dir).unwrap();
         let result = resolve_seed_path(None);
-        std::env::set_current_dir(original_cwd).unwrap();
         assert_eq!(
             result.clone().canonicalize().unwrap(),
             wallet_seed_path.clone().canonicalize().unwrap()


### PR DESCRIPTION
- `SEED_PATH` only defaults to `store` if the `store` directory exists
- if `SEED_PATH` doesn't exist, it will be created
- using `import` command will fail if it will overwrite a file
- use current working directory as base path instead of `CARGO_MANIFEST_DIR`
- add more tests for handling the seed path