### PR TITLE
PLA-2411: Various fixes, bump version to 3.0.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2661,15 +2661,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lru"
-version = "0.16.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
-dependencies = [
- "hashbrown 0.16.1",
-]
-
-[[package]]
 name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4141,7 +4132,7 @@ dependencies = [
  "hex",
  "itertools 0.14.0",
  "log",
- "lru 0.12.5",
+ "lru",
  "parking_lot",
  "pin-project",
  "rand 0.8.5",
@@ -5106,7 +5097,7 @@ dependencies = [
 
 [[package]]
 name = "wallet-daemon"
-version = "3.0.4"
+version = "3.0.5"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -5117,7 +5108,6 @@ dependencies = [
  "graphql_client",
  "hex",
  "hex-literal",
- "lru 0.16.3",
  "parity-scale-codec",
  "rand 0.10.0",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wallet-daemon"
-version = "3.0.4"
+version = "3.0.5"
 edition = "2024"
 
 [[bin]]
@@ -34,7 +34,6 @@ hex = "0.4.3"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 sp-core = { version = "*", default-features = false, features = ["std"] } # match the version subxt uses
 bip39 = { version = "2.2.0", features = ["rand"] }
-lru = "0.16.0"
 hex-literal = "1.1.0"
 scale-info-legacy = "0.4.2"
 aes-gcm = "0.10.3"

--- a/src/global.rs
+++ b/src/global.rs
@@ -3,16 +3,31 @@ use crate::types::{Chain, MetadataInfo, Network};
 use reqwest::header::HeaderMap;
 use std::collections::HashMap;
 use std::sync::{LazyLock, OnceLock};
+use std::time::Duration;
 use subxt::ext::frame_decode::extrinsics::ExtrinsicTypeInfo;
 use tokio::sync::RwLock;
+
+/// Default per-request timeout for all platform GraphQL calls. Without this,
+/// a hung TCP connection on `sign_transactions` (or any other call) would
+/// stall the transaction poller indefinitely under the ack-based
+/// backpressure scheme — the producer awaits the consumer's ack, the
+/// consumer awaits the platform response, and there is no upper bound on
+/// the platform response. 30s is generous for a normally-fast mutation.
+const PLATFORM_HTTP_TIMEOUT: Duration = Duration::from_secs(30);
 
 // Mutable
 /// Stores metadata, spec_version, and client
 static METADATA: LazyLock<RwLock<HashMap<(Network, Chain), MetadataInfo>>> =
     LazyLock::new(|| RwLock::new(HashMap::new()));
 /// The graphql client that fetches chain info
-static GRAPHQL_CLIENT: LazyLock<RwLock<reqwest::Client>> =
-    LazyLock::new(|| RwLock::new(reqwest::Client::new()));
+static GRAPHQL_CLIENT: LazyLock<RwLock<reqwest::Client>> = LazyLock::new(|| {
+    RwLock::new(
+        reqwest::Client::builder()
+            .timeout(PLATFORM_HTTP_TIMEOUT)
+            .build()
+            .expect("failed to build platform GraphQL client"),
+    )
+});
 
 // Immutable
 pub(super) static HEADERS: OnceLock<HeaderMap> = OnceLock::new();

--- a/src/platform_client.rs
+++ b/src/platform_client.rs
@@ -19,7 +19,9 @@ impl PlatformExponentialBuilder {
     }
 }
 
-pub async fn sign_transactions(transactions: Vec<SignTransactionInput>) {
+pub async fn sign_transactions(
+    transactions: Vec<SignTransactionInput>,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let uuids: Vec<_> = transactions.iter().map(|x| x.uuid.clone()).collect();
 
     let res = utils::execute_query::<SignTransactions>(
@@ -38,8 +40,9 @@ pub async fn sign_transactions(transactions: Vec<SignTransactionInput>) {
             for uuid in uuids {
                 tracing::debug!("Signed transaction #{}", uuid);
             }
+            Ok(())
         }
-        Err(e) => tracing::error!("Error sending SignTransactions: {}", e),
+        Err(e) => Err(e),
     }
 }
 

--- a/src/platform_client.rs
+++ b/src/platform_client.rs
@@ -30,9 +30,13 @@ pub async fn sign_transactions(transactions: Vec<SignTransactionInput>) {
 
     match res {
         Ok(r) => {
-            tracing::info!("Response from platform: {:?}", r);
+            tracing::debug!("Response from platform: {:?}", r);
+            tracing::info!(
+                "SignTransactions: {} transaction(s) submitted to platform successfully",
+                uuids.len(),
+            );
             for uuid in uuids {
-                tracing::info!("Signed transaction #{}", uuid);
+                tracing::debug!("Signed transaction #{}", uuid);
             }
         }
         Err(e) => tracing::error!("Error sending SignTransactions: {}", e),

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -34,6 +34,31 @@ type ChainKey = (Network, Chain);
 /// reused for every request signed against that chain in the batch.
 type BlockInfo = (u32, H256, u32);
 
+/// Fatal failure to dispatch a `ProcessorTick` from producer to consumer.
+/// See `send_tick_and_wait` for the rationale on why both variants are
+/// treated as fatal.
+#[derive(Debug)]
+enum TickDispatchError {
+    /// `mpsc::send` failed: the consumer's `Receiver` was dropped, i.e.
+    /// the consumer task has exited.
+    ConsumerGone,
+    /// The ack `oneshot` was dropped without sending: the consumer
+    /// panicked mid-tick (or otherwise abandoned the tick) without
+    /// completing the unconditional ack at the end of `launch_job_scheduler`.
+    AckDropped,
+}
+
+impl std::fmt::Display for TickDispatchError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ConsumerGone => write!(f, "transaction processor receiver dropped"),
+            Self::AckDropped => write!(f, "transaction processor dropped tick ack"),
+        }
+    }
+}
+
+impl std::error::Error for TickDispatchError {}
+
 /// Message sent from the poller to the processor on every poll tick.
 ///
 /// `batch` is the (possibly empty) set of transaction requests pulled this
@@ -192,11 +217,18 @@ impl TransactionJob {
 
     pub fn start(self) -> JoinHandle<()> {
         tokio::spawn(async move {
-            self.start_polling().await;
+            // `start_polling` only returns on a fatal dispatch failure
+            // (consumer task gone or ack dropped). When that happens we
+            // log and let the task complete — `main`'s `tokio::select!`
+            // is watching this `JoinHandle` and will exit the daemon,
+            // letting the process supervisor restart it cleanly.
+            if let Err(e) = self.start_polling().await {
+                tracing::error!("Transaction poller exiting due to fatal error: {e}");
+            }
         })
     }
 
-    async fn start_polling(&self) {
+    async fn start_polling(&self) -> Result<(), TickDispatchError> {
         let mut no_transaction_count = 0;
         // Set of (network, chain) pairs we've ever delivered a batch for. Used
         // to compute the `idle` set: chains we've seen before but didn't see
@@ -227,7 +259,7 @@ impl TransactionJob {
                     if transaction_reqs.is_empty() {
                         if !seen_chains.is_empty() {
                             self.send_tick_and_wait(Vec::new(), seen_chains.clone(), "idle tick")
-                                .await;
+                                .await?;
                         }
                         true
                     } else {
@@ -240,7 +272,7 @@ impl TransactionJob {
                         seen_chains.extend(active.iter().copied());
 
                         self.send_tick_and_wait(transaction_reqs, idle, "transaction requests")
-                            .await;
+                            .await?;
                         no_transaction_count = 0;
                         false
                     }
@@ -257,7 +289,7 @@ impl TransactionJob {
                         // evict their cache entries.
                         if !seen_chains.is_empty() {
                             self.send_tick_and_wait(Vec::new(), seen_chains.clone(), "idle tick")
-                                .await;
+                                .await?;
                         }
                     } else {
                         tracing::error!("Error: {}", e);
@@ -281,20 +313,28 @@ impl TransactionJob {
     /// `kind` is a short label used only in error logs to distinguish the
     /// three send sites ("transaction requests" vs "idle tick").
     ///
-    /// Failure modes are logged and swallowed — there is no point bubbling
-    /// them up because the polling loop has nowhere useful to send them and
-    /// must keep running. If `send().await` fails, the consumer task has
-    /// died, in which case the daemon is in a broken state regardless. If
-    /// the ack channel is dropped without being signaled, the consumer
-    /// finished without acknowledging (this should not happen — the
-    /// consumer always sends the ack on the way out of every tick branch);
-    /// log and proceed so the producer can keep polling.
+    /// Both failure modes are fatal:
+    ///
+    ///   * `mpsc::send` failing means the receiver was dropped, i.e. the
+    ///     consumer task is gone. The mpsc never fails for any other
+    ///     reason — there is no transient case to recover from.
+    ///
+    ///   * The ack oneshot being dropped without a value means the
+    ///     consumer panicked mid-tick (the production code paths always
+    ///     signal the ack on the way out of every branch).
+    ///
+    /// Either way, in-flight batches are lost and there is nothing in
+    /// the current architecture that revives the consumer. Returning
+    /// `Err` here propagates up through `start_polling`, which causes
+    /// the polling task's `JoinHandle` to complete; `main`'s
+    /// `tokio::select!` then exits the daemon, allowing the process
+    /// supervisor to restart it cleanly with a fresh consumer.
     async fn send_tick_and_wait(
         &self,
         batch: Vec<TransactionRequest>,
         idle: HashSet<ChainKey>,
         kind: &str,
-    ) {
+    ) -> Result<(), TickDispatchError> {
         let (ack_tx, ack_rx) = oneshot::channel();
         let tick = ProcessorTick {
             batch,
@@ -303,11 +343,13 @@ impl TransactionJob {
         };
         if let Err(e) = self.sender.send(tick).await {
             tracing::error!("Failed to send {kind} to processor: {e:?}");
-            return;
+            return Err(TickDispatchError::ConsumerGone);
         }
         if let Err(e) = ack_rx.await {
-            tracing::warn!("Processor dropped ack for {kind} without signaling: {e:?}");
+            tracing::error!("Processor dropped ack for {kind} without signaling: {e:?}");
+            return Err(TickDispatchError::AckDropped);
         }
+        Ok(())
     }
 
     async fn get_pending_transactions(
@@ -1162,5 +1204,54 @@ mod tests {
         // Total fetches = distinct keys, not request count.
         assert_eq!(fetch_count.values().sum::<u32>(), 3);
         assert_eq!(refreshed_keys.len(), 3);
+    }
+
+    /// When the consumer's `Receiver` has been dropped (consumer task
+    /// has exited), `send_tick_and_wait` must return
+    /// `TickDispatchError::ConsumerGone` rather than logging and
+    /// silently returning. This is what allows the producer's polling
+    /// loop to terminate the daemon instead of degenerating into a
+    /// tight loop hammering the platform with `GetPendingTransactions`
+    /// while every dispatch fails.
+    #[tokio::test]
+    async fn send_tick_and_wait_returns_consumer_gone_when_receiver_dropped() {
+        let (sender, receiver) = tokio::sync::mpsc::channel::<ProcessorTick>(1);
+        let job = TransactionJob::new(sender);
+        // Drop the receiver -> any subsequent send fails with
+        // `mpsc::error::SendError`, which is the exact failure mode the
+        // reviewer flagged.
+        drop(receiver);
+
+        let result = job
+            .send_tick_and_wait(Vec::new(), HashSet::new(), "test idle tick")
+            .await;
+
+        assert!(matches!(result, Err(TickDispatchError::ConsumerGone)));
+    }
+
+    /// When the consumer accepts the tick but drops the ack `oneshot`
+    /// without signaling (i.e. panics mid-tick), `send_tick_and_wait`
+    /// must return `TickDispatchError::AckDropped`. This too is fatal:
+    /// it indicates the consumer has abandoned a tick and we have no
+    /// guarantee the corresponding `SignTransactions` was issued.
+    #[tokio::test]
+    async fn send_tick_and_wait_returns_ack_dropped_when_consumer_drops_ack() {
+        let (sender, mut receiver) = tokio::sync::mpsc::channel::<ProcessorTick>(1);
+        let job = TransactionJob::new(sender);
+
+        // Pretend to be a consumer that accepts the tick (drains the
+        // mpsc) but then drops the ack without signaling.
+        let consumer = tokio::spawn(async move {
+            if let Some(tick) = receiver.recv().await {
+                drop(tick.ack);
+            }
+        });
+
+        let result = job
+            .send_tick_and_wait(Vec::new(), HashSet::new(), "test idle tick")
+            .await;
+        consumer.await.unwrap();
+
+        assert!(matches!(result, Err(TickDispatchError::AckDropped)));
     }
 }

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -592,6 +592,8 @@ impl TransactionProcessor {
         // (see the `Err` arm after the loop).
         let mut committed_keys: HashSet<NonceKey> = HashSet::new();
 
+        let request_count = requests.len();
+
         for (signer, request) in signers.into_iter().zip(requests) {
             let TransactionRequest {
                 request_id,
@@ -782,6 +784,15 @@ impl TransactionProcessor {
             // batch's `SignTransactions` mutation ultimately fails.
             *nonce_slot += 1;
             committed_keys.insert(nonce_key);
+        }
+
+        // Short-circuit if every request in this batch was skipped
+        // (failed prefetch, failed signing, etc.)
+        if inputs.is_empty() {
+            tracing::debug!(
+                "SignTransactions: nothing to submit (all {request_count} request(s) in this batch were skipped)",
+            );
+            return;
         }
 
         // Snapshot the uuids actually queued for submission so we can name

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -23,8 +23,8 @@ const NO_TRANSACTIONS_MSG: &str = "No transactions present in the body";
 const TRANSACTION_POLLER_MS: u64 = 6000;
 const TRANSACTION_PAGE_SIZE: i64 = 25;
 
-/// Per-batch nonce map key. Each `(network, chain, signer public key)` tracks
-/// its own counter for the duration of a single batch.
+/// Nonce cache key. Each `(network, chain, signer public key)` identifies
+/// a signer-specific counter that may persist across batches until evicted.
 type NonceKey = (Network, Chain, [u8; 32]);
 
 /// Per-batch chain key for block / metadata prefetch.

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -16,7 +16,7 @@ use subxt_signer::DeriveJunction;
 use subxt_signer::sr25519::Keypair;
 use tokio::sync::mpsc::{Receiver, Sender};
 use tokio::task::JoinHandle;
-use tokio::time::interval;
+use tokio::time::sleep;
 
 const NO_TRANSACTIONS_MSG: &str = "No transactions present in the body";
 const TRANSACTION_POLLER_MS: u64 = 6000;
@@ -180,8 +180,6 @@ impl TransactionJob {
     }
 
     async fn start_polling(&self) {
-        let mut interval = interval(Duration::from_millis(TRANSACTION_POLLER_MS));
-        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
         let mut no_transaction_count = 0;
         // Set of (network, chain) pairs we've ever delivered a batch for. Used
         // to compute the `idle` set: chains we've seen before but didn't see
@@ -190,9 +188,10 @@ impl TransactionJob {
         let mut seen_chains: HashSet<ChainKey> = HashSet::new();
 
         loop {
-            interval.tick().await;
-
-            match self.get_pending_transactions().await {
+            // Only sleep when there is no work to do (or on error). When a
+            // batch was successfully delivered, we immediately poll again to
+            // drain any remaining backlog.
+            let should_sleep = match self.get_pending_transactions().await {
                 Ok(transaction_reqs) => {
                     let active: HashSet<ChainKey> = transaction_reqs
                         .iter()
@@ -210,6 +209,7 @@ impl TransactionJob {
                         tracing::info!("Error sending transaction requests: {:?}", e);
                     }
                     no_transaction_count = 0;
+                    false
                 }
                 Err(e) => {
                     if e.to_string() == NO_TRANSACTIONS_MSG {
@@ -233,7 +233,12 @@ impl TransactionJob {
                     } else {
                         tracing::error!("Error: {}", e);
                     }
+                    true
                 }
+            };
+
+            if should_sleep {
+                sleep(Duration::from_millis(TRANSACTION_POLLER_MS)).await;
             }
         }
     }

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -33,6 +33,20 @@ type ChainKey = (Network, Chain);
 /// reused for every request signed against that chain in the batch.
 type BlockInfo = (u32, H256, u32);
 
+/// Message sent from the poller to the processor on every poll tick.
+///
+/// `batch` is the (possibly empty) set of transaction requests pulled this
+/// tick. `idle` is the set of `(network, chain)` pairs that the poller has
+/// previously delivered txs for but did **not** see in this tick's response —
+/// the processor uses this to evict their nonce-cache entries so the next
+/// batch for those chains re-reads the on-chain nonce from scratch. This
+/// prevents long-term cross-batch nonce desync while letting back-to-back
+/// batches reuse the in-memory counter.
+pub struct ProcessorTick {
+    batch: Vec<TransactionRequest>,
+    idle: HashSet<ChainKey>,
+}
+
 pub(crate) mod payload {
     use crate::global;
     use crate::types::{Chain, Network};
@@ -142,11 +156,11 @@ impl TryFrom<get_pending_transactions::GetPendingTransactionsResultData> for Tra
 
 #[derive(Debug)]
 pub struct TransactionJob {
-    sender: Sender<Vec<TransactionRequest>>,
+    sender: Sender<ProcessorTick>,
 }
 
 impl TransactionJob {
-    pub fn new(sender: Sender<Vec<TransactionRequest>>) -> Self {
+    pub fn new(sender: Sender<ProcessorTick>) -> Self {
         Self { sender }
     }
 
@@ -169,13 +183,30 @@ impl TransactionJob {
         let mut interval = interval(Duration::from_millis(TRANSACTION_POLLER_MS));
         interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
         let mut no_transaction_count = 0;
+        // Set of (network, chain) pairs we've ever delivered a batch for. Used
+        // to compute the `idle` set: chains we've seen before but didn't see
+        // this tick. The cache for any chain in `idle` will be evicted on the
+        // consumer side.
+        let mut seen_chains: HashSet<ChainKey> = HashSet::new();
 
         loop {
             interval.tick().await;
 
             match self.get_pending_transactions().await {
                 Ok(transaction_reqs) => {
-                    if let Err(e) = self.sender.try_send(transaction_reqs) {
+                    let active: HashSet<ChainKey> = transaction_reqs
+                        .iter()
+                        .map(|r| (r.network, r.chain))
+                        .collect();
+                    let idle: HashSet<ChainKey> =
+                        seen_chains.difference(&active).copied().collect();
+                    seen_chains.extend(active.iter().copied());
+
+                    let tick = ProcessorTick {
+                        batch: transaction_reqs,
+                        idle,
+                    };
+                    if let Err(e) = self.sender.try_send(tick) {
                         tracing::info!("Error sending transaction requests: {:?}", e);
                     }
                     no_transaction_count = 0;
@@ -186,6 +217,19 @@ impl TransactionJob {
                             tracing::info!("GetPendingTransactions: {}", NO_TRANSACTIONS_MSG,);
                         }
                         no_transaction_count += 1;
+
+                        // Empty poll: every chain we've ever seen is idle this
+                        // tick. Send an empty-batch tick so the consumer can
+                        // evict their cache entries.
+                        if !seen_chains.is_empty() {
+                            let tick = ProcessorTick {
+                                batch: Vec::new(),
+                                idle: seen_chains.clone(),
+                            };
+                            if let Err(e) = self.sender.try_send(tick) {
+                                tracing::info!("Error sending idle tick: {:?}", e);
+                            }
+                        }
                     } else {
                         tracing::error!("Error: {}", e);
                     }
@@ -228,15 +272,28 @@ impl TransactionJob {
 
 pub struct TransactionProcessor {
     keypair: Keypair,
-    receiver: Receiver<Vec<TransactionRequest>>,
+    receiver: Receiver<ProcessorTick>,
+    /// Persistent nonce cache. The slot for `(network, chain, signer)` holds
+    /// the next nonce to use for that triple. Survives across batches so that
+    /// back-to-back batches stay in sync; entries are evicted when the poller
+    /// reports a chain has gone idle (see `ProcessorTick::idle`).
+    nonces: HashMap<NonceKey, u64>,
 }
 
 impl TransactionProcessor {
-    pub(crate) fn new(keypair: Keypair, receiver: Receiver<Vec<TransactionRequest>>) -> Self {
-        Self { keypair, receiver }
+    pub(crate) fn new(keypair: Keypair, receiver: Receiver<ProcessorTick>) -> Self {
+        Self {
+            keypair,
+            receiver,
+            nonces: HashMap::new(),
+        }
     }
 
-    async fn transaction_handler(keypair: Keypair, requests: Vec<TransactionRequest>) {
+    async fn transaction_handler(
+        keypair: Keypair,
+        nonces: &mut HashMap<NonceKey, u64>,
+        requests: Vec<TransactionRequest>,
+    ) {
         // Derive the signer for every request up-front so we can both
         // pre-fetch nonces and reuse the keypair in the main signing loop.
         let signers: Vec<Keypair> = requests
@@ -296,10 +353,12 @@ impl TransactionProcessor {
             block_info.insert(key, (block_number, block_hash, spec_version));
         }
 
-        // Pre-fetch the starting nonce once per unique (network, chain, signer)
-        // triple in this batch. We assume the platform's `get_account_nonce`
-        // resolver returns `system_accountNextIndex`.
-        let mut nonces: HashMap<NonceKey, u64> = HashMap::new();
+        // Seed the persistent nonce cache for any (network, chain, signer)
+        // triple in this batch that doesn't already have an entry. Triples
+        // with an existing cache entry are NOT re-fetched — that's how we
+        // carry the counter across back-to-back batches. The empty-poll
+        // reset (handled in `launch_job_scheduler`) is what eventually
+        // evicts a stale entry when a chain goes quiet.
         let mut failed_keys: HashSet<NonceKey> = HashSet::new();
         for (signer, request) in signers.iter().zip(requests.iter()) {
             // Don't bother fetching a nonce for a chain that already failed
@@ -545,12 +604,29 @@ impl TransactionProcessor {
     }
 
     async fn launch_job_scheduler(mut self) {
-        // Process one batch at a time. Awaiting the handler (rather than
+        // Process one tick at a time. Awaiting the handler (rather than
         // `tokio::spawn`ing it) guarantees the previous batch is fully signed
         // and submitted before the next one starts, which is required for
         // correct nonce sequencing.
-        while let Some(requests) = self.receiver.recv().await {
-            Self::transaction_handler(self.keypair.clone(), requests).await;
+        while let Some(ProcessorTick { batch, idle }) = self.receiver.recv().await {
+            // Apply idle resets BEFORE processing the batch. By construction
+            // the poller never includes a chain in both `batch` and `idle` for
+            // the same tick, but applying resets first keeps semantics
+            // unambiguous if that invariant ever changes.
+            if !idle.is_empty() {
+                let evicted = evict_idle_chains(&mut self.nonces, &idle);
+                if evicted > 0 {
+                    tracing::debug!(
+                        "Reset nonce cache for {} idle chain(s) ({} entries evicted)",
+                        idle.len(),
+                        evicted,
+                    );
+                }
+            }
+
+            if !batch.is_empty() {
+                Self::transaction_handler(self.keypair.clone(), &mut self.nonces, batch).await;
+            }
         }
     }
 
@@ -578,6 +654,16 @@ fn derive_signer(keypair: &Keypair, external_id: Option<&str>) -> Keypair {
         }
         None => keypair.clone(),
     }
+}
+
+/// Drop every nonce-cache entry whose `(network, chain)` is in `idle`. Used
+/// to flush stale counters when the poller reports a chain has gone quiet so
+/// the next batch for that chain re-reads the on-chain nonce. Returns the
+/// number of entries actually evicted.
+fn evict_idle_chains(nonces: &mut HashMap<NonceKey, u64>, idle: &HashSet<ChainKey>) -> usize {
+    let before = nonces.len();
+    nonces.retain(|(net, chain, _), _| !idle.contains(&(*net, *chain)));
+    before - nonces.len()
 }
 
 #[cfg(test)]
@@ -663,5 +749,84 @@ mod tests {
         }
 
         assert_eq!(nonces[&key], 12);
+    }
+
+    /// Cross-batch carry-over: a triple that already has a cache entry from
+    /// a previous batch must NOT be re-seeded when the next batch starts. The
+    /// next batch picks up where the previous one left off.
+    ///
+    /// This mirrors the seed-on-miss check in `transaction_handler`'s nonce
+    /// prefetch (`if nonces.contains_key(&key) || failed_keys.contains(&key)
+    /// { continue; }`). A miss would call out to chain; a hit must short-
+    /// circuit.
+    #[test]
+    fn cache_carry_over_skips_chain_fetch_on_hit() {
+        let mut nonces: HashMap<NonceKey, u64> = HashMap::new();
+        let key: NonceKey = (Network::Enjin, Chain::Matrix, [0u8; 32]);
+
+        // Simulate end-of-batch-1 state: 25 txs signed starting at chain
+        // nonce 21, slot now holds 46 (= 21 + 25).
+        nonces.insert(key, 46);
+
+        // Batch 2 starts. The prefetch decision is `nonces.contains_key(&key)`.
+        // A hit means we do NOT fetch from chain; we just reuse the slot.
+        let would_fetch_from_chain = !nonces.contains_key(&key);
+        assert!(
+            !would_fetch_from_chain,
+            "cache hit must not trigger a chain fetch"
+        );
+
+        // The next signed tx in batch 2 must therefore use 46, not 21.
+        let slot = nonces.get_mut(&key).unwrap();
+        assert_eq!(
+            *slot, 46,
+            "batch 2 must continue from where batch 1 left off"
+        );
+        *slot += 1;
+        assert_eq!(nonces[&key], 47);
+    }
+
+    /// Reset-on-idle: when the poller reports a chain went idle, every cache
+    /// entry for that chain (across all signing keys) must be evicted, while
+    /// other chains' entries remain intact.
+    #[test]
+    fn evict_idle_chains_drops_only_matching_chains() {
+        let mut nonces: HashMap<NonceKey, u64> = HashMap::new();
+
+        let alice = [0xAAu8; 32];
+        let bob = [0xBBu8; 32];
+
+        // Two signers active on Enjin Matrix.
+        nonces.insert((Network::Enjin, Chain::Matrix, alice), 5);
+        nonces.insert((Network::Enjin, Chain::Matrix, bob), 9);
+        // One signer active on Enjin Relay.
+        nonces.insert((Network::Enjin, Chain::Relay, alice), 12);
+        // One signer active on Canary Matrix.
+        nonces.insert((Network::Canary, Chain::Matrix, alice), 3);
+
+        // Poller reports: Enjin Matrix went idle this tick.
+        let idle: HashSet<ChainKey> = [(Network::Enjin, Chain::Matrix)].into_iter().collect();
+        evict_idle_chains(&mut nonces, &idle);
+
+        // Both Enjin Matrix entries (Alice + Bob) must be gone.
+        assert!(!nonces.contains_key(&(Network::Enjin, Chain::Matrix, alice)));
+        assert!(!nonces.contains_key(&(Network::Enjin, Chain::Matrix, bob)));
+
+        // Other chains are untouched.
+        assert_eq!(nonces[&(Network::Enjin, Chain::Relay, alice)], 12);
+        assert_eq!(nonces[&(Network::Canary, Chain::Matrix, alice)], 3);
+        assert_eq!(nonces.len(), 2);
+    }
+
+    /// A no-op idle set must not touch anything.
+    #[test]
+    fn evict_idle_chains_empty_set_is_noop() {
+        let mut nonces: HashMap<NonceKey, u64> = HashMap::new();
+        nonces.insert((Network::Enjin, Chain::Matrix, [0u8; 32]), 7);
+
+        evict_idle_chains(&mut nonces, &HashSet::new());
+
+        assert_eq!(nonces[&(Network::Enjin, Chain::Matrix, [0u8; 32])], 7);
+        assert_eq!(nonces.len(), 1);
     }
 }

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -236,14 +236,40 @@ impl TransactionJob {
         // consumer side.
         let mut seen_chains: HashSet<ChainKey> = HashSet::new();
 
+        // Persistent cursor for `GetPendingTransactions`. We pass the
+        // cursor we received on the previous successful poll back to the
+        // platform on the next poll. The platform uses the cursor as a
+        // backend pagination/scan hint, so providing it lets the server
+        // skip work it has already returned to us. Each `Ok` page we
+        // receive is capped at `TRANSACTION_PAGE_SIZE = 25` (the
+        // server-side `limit` parameter), and we deliver exactly one
+        // page per tick — that is what enforces the per-batch cap of
+        // 25 on the consumer side, and therefore on the
+        // `SignTransactions` mutation.
+        //
+        // We reset the cursor to `None` whenever a poll does not
+        // successfully advance us (empty result, `NO_TRANSACTIONS_MSG`,
+        // or any other error). The cursor is only meaningful relative
+        // to a server-side scan that is still in progress; once we go
+        // quiet, we should rejoin the stream from the beginning on our
+        // next poll.
+        let mut cursor: Option<String> = None;
+
         loop {
             // Sleep when there is no work to do (or on error). When a
-            // non-empty batch was successfully delivered, we immediately
-            // re-poll to catch any transactions that were added to the
-            // queue while we were signing the previous batch (signing can
-            // take several seconds; pagination already drained the visible
-            // backlog in a single call, so this re-poll is purely about
-            // picking up newly-arrived work).
+            // non-empty page was successfully delivered, we immediately
+            // re-poll. Two distinct reasons motivate the no-sleep path:
+            //
+            //   * Drain-in-progress: the server returned a `nextCursor`,
+            //     meaning more pending transactions are waiting. We
+            //     hand off the 25-tx batch to the consumer, await its
+            //     ack, then immediately re-poll with the carried-over
+            //     cursor to pick up the next 25.
+            //
+            //   * No cursor but the queue may have grown: signing can
+            //     take several seconds; new transactions may have
+            //     arrived while we were signing the previous batch.
+            //     Re-polling immediately picks those up.
             //
             // Critically, we await the consumer's ack between sending a
             // tick and the next poll. Without that, the producer can race
@@ -251,12 +277,17 @@ impl TransactionJob {
             // consumer has submitted the corresponding `SignTransactions`
             // mutation, causing the same uuid to be signed with consecutive
             // nonces and rejected by the platform.
-            let should_sleep = match self.get_pending_transactions().await {
-                Ok(transaction_reqs) => {
-                    // Treat an empty `Ok` (e.g. every item on page 1 failed
-                    // `TryFrom`) the same as `NO_TRANSACTIONS_MSG`: back off
-                    // instead of busy-looping on a broken-data condition.
+            let should_sleep = match self.get_pending_transactions(cursor.clone()).await {
+                Ok((transaction_reqs, next_cursor)) => {
+                    // Treat an empty `Ok` (e.g. every item on the page
+                    // failed `TryFrom`) the same as `NO_TRANSACTIONS_MSG`:
+                    // back off instead of busy-looping on a broken-data
+                    // condition. We deliberately drop `next_cursor` here
+                    // even if non-null — if the page we got was unusable,
+                    // continuing to drain via that cursor would just
+                    // produce more unusable pages.
                     if transaction_reqs.is_empty() {
+                        cursor = None;
                         if !seen_chains.is_empty() {
                             self.send_tick_and_wait(Vec::new(), seen_chains.clone(), "idle tick")
                                 .await?;
@@ -274,10 +305,18 @@ impl TransactionJob {
                         self.send_tick_and_wait(transaction_reqs, idle, "transaction requests")
                             .await?;
                         no_transaction_count = 0;
+                        // Carry the cursor forward for the next poll
+                        // when the server says there is more pending,
+                        // and clear it otherwise.
+                        cursor = next_cursor;
                         false
                     }
                 }
                 Err(e) => {
+                    // Any error path resets the cursor: a stale cursor
+                    // is meaningless after we've lost our place in the
+                    // server-side scan.
+                    cursor = None;
                     if e.to_string() == NO_TRANSACTIONS_MSG {
                         if no_transaction_count % 10 == 0 {
                             tracing::info!("GetPendingTransactions: {}", NO_TRANSACTIONS_MSG,);
@@ -352,78 +391,60 @@ impl TransactionJob {
         Ok(())
     }
 
+    /// Fetch one page (up to `TRANSACTION_PAGE_SIZE` items) of pending
+    /// transactions, optionally resuming a server-side scan via
+    /// `cursor`. Returns the decoded `TransactionRequest`s alongside
+    /// the platform's `nextCursor`, which the caller carries forward
+    /// to the next poll when the platform indicates more pending work
+    /// is available.
     async fn get_pending_transactions(
         &self,
-    ) -> Result<Vec<TransactionRequest>, Box<dyn std::error::Error + Send + Sync>> {
-        let mut all: Vec<TransactionRequest> = Vec::new();
-        let mut cursor: Option<String> = None;
-        let mut page_index: usize = 0;
+        cursor: Option<String>,
+    ) -> Result<(Vec<TransactionRequest>, Option<String>), Box<dyn std::error::Error + Send + Sync>>
+    {
+        let response_data = utils::execute_query::<GetPendingTransactions>(
+            get_pending_transactions::Variables {
+                limit: TRANSACTION_PAGE_SIZE,
+                cursor,
+            },
+            None,
+        )
+        .await?;
 
-        loop {
-            let response_data = utils::execute_query::<GetPendingTransactions>(
-                get_pending_transactions::Variables {
-                    limit: TRANSACTION_PAGE_SIZE,
-                    cursor: cursor.clone(),
-                },
-                None,
-            )
-            .await?;
+        let result = match response_data.result {
+            Some(r) => r,
+            None => return Err(NO_TRANSACTIONS_MSG.into()),
+        };
 
-            let result = match response_data.result {
-                Some(r) => r,
-                None => {
-                    // First page: no result at all -> nothing pending.
-                    // Later page: server gave us a `nextCursor` but then
-                    // returned no result; treat as end-of-stream.
-                    if page_index == 0 {
-                        return Err(NO_TRANSACTIONS_MSG.into());
-                    }
-                    break;
-                }
-            };
+        let page = result.data;
+        let next_cursor = match result.next_cursor {
+            Some(c) if !c.is_empty() => Some(c),
+            _ => None,
+        };
 
-            let page = result.data;
-            let next_cursor = result.next_cursor;
-            let page_len = page.len();
+        if page.is_empty() {
+            return Err(NO_TRANSACTIONS_MSG.into());
+        }
 
-            if page_index == 0 && page.is_empty() {
-                return Err(NO_TRANSACTIONS_MSG.into());
-            }
-
-            all.extend(page.into_iter().filter_map(|p| {
+        let requests: Vec<TransactionRequest> = page
+            .into_iter()
+            .filter_map(|p| {
                 TransactionRequest::try_from(p)
                     .map_err(|e| {
                         tracing::error!("Error creating TransactionRequest: {}", e);
                         e
                     })
                     .ok()
-            }));
+            })
+            .collect();
 
-            tracing::debug!(
-                "GetPendingTransactions: fetched page {} ({} items, total so far: {}), next_cursor present: {}",
-                page_index,
-                page_len,
-                all.len(),
-                next_cursor.is_some(),
-            );
+        tracing::debug!(
+            "GetPendingTransactions: {} request(s) returned, next_cursor present: {}",
+            requests.len(),
+            next_cursor.is_some(),
+        );
 
-            page_index += 1;
-
-            match next_cursor {
-                Some(c) if !c.is_empty() => cursor = Some(c),
-                _ => break,
-            }
-        }
-
-        if page_index > 1 {
-            tracing::info!(
-                "GetPendingTransactions: drained {} pages, {} transaction(s) total",
-                page_index,
-                all.len(),
-            );
-        }
-
-        Ok(all)
+        Ok((requests, next_cursor))
     }
 }
 

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -468,13 +468,30 @@ impl TransactionProcessor {
             block_info.insert(key, (block_number, block_hash, spec_version));
         }
 
-        // Seed the persistent nonce cache for any (network, chain, signer)
-        // triple in this batch that doesn't already have an entry. Triples
-        // with an existing cache entry are NOT re-fetched — that's how we
-        // carry the counter across back-to-back batches. The empty-poll
-        // reset (handled in `launch_job_scheduler`) is what eventually
-        // evicts a stale entry when a chain goes quiet.
+        // Seed (or refresh) the persistent nonce cache for every
+        // (network, chain, signer) triple in this batch. We fetch the
+        // on-chain nonce once per key per batch and rebase the cached
+        // slot to `max(slot, chain_nonce)`:
+        //
+        //   * If `slot >= chain_nonce`, the cache is preserved. This is
+        //     the common back-to-back-batch case: our previous batch
+        //     advanced the slot, the chain hasn't caught up to those
+        //     extrinsics yet, and the slot is still the right next
+        //     nonce to use.
+        //
+        //   * If `slot < chain_nonce`, something moved the on-chain
+        //     nonce forward out-of-band (a different daemon, a manual
+        //     extrinsic, the platform using a different code path,
+        //     etc.). Without this rebase, the daemon would happily keep
+        //     signing with the stale cached value and produce stale-
+        //     nonce extrinsics that the chain rejects silently. Empty-
+        //     poll cache eviction does NOT cover this case, because the
+        //     chain is still active in our daemon's view.
+        //
         let mut failed_keys: HashSet<NonceKey> = HashSet::new();
+        // Per-batch dedup: we want exactly one chain fetch per key per
+        // batch, even when the same triple appears across many requests.
+        let mut refreshed_keys: HashSet<NonceKey> = HashSet::new();
         for (signer, request) in signers.iter().zip(requests.iter()) {
             // Don't bother fetching a nonce for a chain that already failed
             // its block / metadata prefetch.
@@ -482,7 +499,7 @@ impl TransactionProcessor {
                 continue;
             }
             let key: NonceKey = (request.network, request.chain, signer.public_key().0);
-            if nonces.contains_key(&key) || failed_keys.contains(&key) {
+            if refreshed_keys.contains(&key) || failed_keys.contains(&key) {
                 continue;
             }
             match chain_info::get_account_nonce(
@@ -492,14 +509,27 @@ impl TransactionProcessor {
             )
             .await
             {
-                Ok(n) => {
-                    tracing::debug!(
-                        "Prefetched nonce {n} for acc 0x{} - Network: {:?} - Chain: {:?}",
-                        hex::encode(key.2),
-                        request.network,
-                        request.chain,
-                    );
-                    nonces.insert(key, n);
+                Ok(chain_nonce) => {
+                    let slot = nonces.entry(key).or_insert(chain_nonce);
+                    if *slot < chain_nonce {
+                        let was = *slot;
+                        *slot = chain_nonce;
+                        tracing::info!(
+                            "Detected out-of-band nonce advance for account 0x{} - Network: {:?} - Chain: {:?}; rebasing cache from {was} to {chain_nonce}",
+                            hex::encode(key.2),
+                            request.network,
+                            request.chain,
+                        );
+                    } else {
+                        let cached = *slot;
+                        tracing::debug!(
+                            "Refreshed nonce: cache={cached} chain={chain_nonce} for account 0x{} - Network: {:?} - Chain: {:?}",
+                            hex::encode(key.2),
+                            request.network,
+                            request.chain,
+                        );
+                    }
+                    refreshed_keys.insert(key);
                 }
                 Err(e) => {
                     tracing::error!(
@@ -909,39 +939,79 @@ mod tests {
         assert_eq!(nonces[&key], 12);
     }
 
-    /// Cross-batch carry-over: a triple that already has a cache entry from
-    /// a previous batch must NOT be re-seeded when the next batch starts. The
-    /// next batch picks up where the previous one left off.
+    /// Cross-batch carry-over: when the chain has not yet caught up to
+    /// our previously-signed extrinsics, the cached slot must be
+    /// preserved across batches. This is the common case for back-to-
+    /// back batches against the same `(network, chain, signer)`: our
+    /// previous batch's extrinsics are still propagating / awaiting
+    /// inclusion, so the chain still reports the pre-batch nonce, but
+    /// we must keep using our advanced cache.
     ///
-    /// This mirrors the seed-on-miss check in `transaction_handler`'s nonce
-    /// prefetch (`if nonces.contains_key(&key) || failed_keys.contains(&key)
-    /// { continue; }`). A miss would call out to chain; a hit must short-
-    /// circuit.
+    /// Mirrors the `max(slot, chain_nonce)` rebase in
+    /// `transaction_handler`'s seed loop: when `slot >= chain_nonce`,
+    /// the slot is unchanged.
     #[test]
-    fn cache_carry_over_skips_chain_fetch_on_hit() {
+    fn cache_carry_over_preserves_slot_when_chain_is_behind() {
         let mut nonces: HashMap<NonceKey, u64> = HashMap::new();
         let key: NonceKey = (Network::Enjin, Chain::Matrix, [0u8; 32]);
 
-        // Simulate end-of-batch-1 state: 25 txs signed starting at chain
-        // nonce 21, slot now holds 46 (= 21 + 25).
+        // End-of-batch-1 state: 25 txs signed starting at chain nonce
+        // 21, slot now holds 46 (= 21 + 25). The chain still reports 21
+        // because none of those extrinsics have been included yet.
         nonces.insert(key, 46);
+        let chain_nonce: u64 = 21;
 
-        // Batch 2 starts. The prefetch decision is `nonces.contains_key(&key)`.
-        // A hit means we do NOT fetch from chain; we just reuse the slot.
-        let would_fetch_from_chain = !nonces.contains_key(&key);
-        assert!(
-            !would_fetch_from_chain,
-            "cache hit must not trigger a chain fetch"
-        );
-
-        // The next signed tx in batch 2 must therefore use 46, not 21.
+        // Apply the same rebase rule as the production seed loop:
+        // `slot = max(slot, chain_nonce)`. When the chain is behind us
+        // the slot must remain at 46.
         let slot = nonces.get_mut(&key).unwrap();
+        if *slot < chain_nonce {
+            *slot = chain_nonce;
+        }
         assert_eq!(
             *slot, 46,
-            "batch 2 must continue from where batch 1 left off"
+            "slot must be preserved when chain is behind the cache"
         );
+
+        // The next signed tx must therefore use 46, not 21.
         *slot += 1;
         assert_eq!(nonces[&key], 47);
+    }
+
+    /// Out-of-band advance: when the on-chain nonce has moved past the
+    /// cached slot (because some other process — another daemon, a
+    /// manual extrinsic, etc. — used the same account), the cache must
+    /// be rebased to the chain's value before signing. Otherwise the
+    /// daemon would keep producing stale-nonce extrinsics that the
+    /// chain rejects silently. This is the bug the second reviewer
+    /// flagged.
+    ///
+    /// Mirrors the `max(slot, chain_nonce)` rebase in
+    /// `transaction_handler`'s seed loop: when `slot < chain_nonce`,
+    /// the slot is bumped up.
+    #[test]
+    fn cache_rebases_to_chain_when_chain_advances_out_of_band() {
+        let mut nonces: HashMap<NonceKey, u64> = HashMap::new();
+        let key: NonceKey = (Network::Enjin, Chain::Matrix, [0u8; 32]);
+
+        // Cache says next nonce is 30 (e.g. we last signed nonce 29).
+        nonces.insert(key, 30);
+        // Meanwhile the chain has moved to 35 because something else
+        // signed nonces 30..35 with this account.
+        let chain_nonce: u64 = 35;
+
+        let slot = nonces.get_mut(&key).unwrap();
+        if *slot < chain_nonce {
+            *slot = chain_nonce;
+        }
+        assert_eq!(
+            *slot, 35,
+            "slot must be rebased to chain when chain has advanced past the cache"
+        );
+
+        // The next signed tx must therefore use 35, not 30.
+        *slot += 1;
+        assert_eq!(nonces[&key], 36);
     }
 
     /// Reset-on-idle: when the poller reports a chain went idle, every cache
@@ -1042,5 +1112,55 @@ mod tests {
         assert_eq!(evicted, 0);
         assert_eq!(nonces[&(Network::Enjin, Chain::Matrix, [0u8; 32])], 7);
         assert_eq!(nonces.len(), 1);
+    }
+
+    /// Per-batch dedup invariant: when a batch contains many requests
+    /// for the same `(network, chain, signer)` triple, the seed loop
+    /// must call out to chain exactly once for that key. Otherwise we'd
+    /// pay one chain RPC per request (catastrophic for batches of 25)
+    /// and — worse — every fetch after the first would clobber the
+    /// in-flight slot we've already started advancing.
+    ///
+    /// The production loop tracks this via a `refreshed_keys: HashSet`
+    /// guard: the first encounter inserts into the set and fetches; all
+    /// subsequent encounters short-circuit. This test models that
+    /// guard.
+    #[test]
+    fn seed_loop_fetches_each_key_exactly_once_per_batch() {
+        let alice = [0xAAu8; 32];
+        let bob = [0xBBu8; 32];
+
+        // Simulated batch: 5 requests, three of them are Alice on Enjin
+        // Matrix (the duplicates), one is Bob on Enjin Matrix, one is
+        // Alice on Canary Matrix.
+        let batch: Vec<NonceKey> = vec![
+            (Network::Enjin, Chain::Matrix, alice),
+            (Network::Enjin, Chain::Matrix, alice),
+            (Network::Enjin, Chain::Matrix, bob),
+            (Network::Enjin, Chain::Matrix, alice),
+            (Network::Canary, Chain::Matrix, alice),
+        ];
+
+        let mut refreshed_keys: HashSet<NonceKey> = HashSet::new();
+        let mut fetch_count: HashMap<NonceKey, u32> = HashMap::new();
+
+        for key in &batch {
+            if refreshed_keys.contains(key) {
+                continue;
+            }
+            // This branch models the chain RPC.
+            *fetch_count.entry(*key).or_insert(0) += 1;
+            refreshed_keys.insert(*key);
+        }
+
+        // Each distinct key fetched exactly once...
+        assert_eq!(fetch_count[&(Network::Enjin, Chain::Matrix, alice)], 1);
+        assert_eq!(fetch_count[&(Network::Enjin, Chain::Matrix, bob)], 1);
+        assert_eq!(fetch_count[&(Network::Canary, Chain::Matrix, alice)], 1);
+        // ...and no other keys were fetched.
+        assert_eq!(fetch_count.len(), 3);
+        // Total fetches = distinct keys, not request count.
+        assert_eq!(fetch_count.values().sum::<u32>(), 3);
+        assert_eq!(refreshed_keys.len(), 3);
     }
 }

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -149,7 +149,7 @@ impl TryFrom<get_pending_transactions::GetPendingTransactionsResultData> for Tra
     fn try_from(
         data: get_pending_transactions::GetPendingTransactionsResultData,
     ) -> Result<Self, Self::Error> {
-        tracing::info!("{:?}", data);
+        tracing::debug!("{:?}", data);
         let external_id = data.wallet.external_id.clone();
 
         Ok(Self {
@@ -460,7 +460,7 @@ impl TransactionProcessor {
                 continue;
             }
 
-            tracing::info!(
+            tracing::debug!(
                 "Prefetched block {block_number} (spec {spec_version}) for {:?}/{:?}",
                 request.network,
                 request.chain,
@@ -493,9 +493,9 @@ impl TransactionProcessor {
             .await
             {
                 Ok(n) => {
-                    tracing::info!(
-                        "Prefetched nonce {n} for acc {} - Network: {:?} - Chain: {:?}",
-                        trim_account(hex::encode(key.2)),
+                    tracing::debug!(
+                        "Prefetched nonce {n} for acc 0x{} - Network: {:?} - Chain: {:?}",
+                        hex::encode(key.2),
                         request.network,
                         request.chain,
                     );
@@ -524,7 +524,6 @@ impl TransactionProcessor {
                 mut payload,
                 fuel_tank_signer_external_id,
             } = request;
-            tracing::info!("Received transaction request: #{request_id}");
 
             let pubkey_bytes = signer.public_key().0;
             let nonce_key: NonceKey = (network, chain, pubkey_bytes);
@@ -553,12 +552,6 @@ impl TransactionProcessor {
                 continue;
             };
 
-            tracing::info!(
-                "Signing transaction #{} with account {}",
-                request_id,
-                hex::encode(pubkey_bytes)
-            );
-
             let Some(nonce_slot) = nonces.get_mut(&nonce_key) else {
                 tracing::error!(
                     "missing pre-fetched nonce for {} on {network:?}/{chain:?}",
@@ -567,10 +560,6 @@ impl TransactionProcessor {
                 continue;
             };
             let correct_nonce = *nonce_slot;
-            tracing::info!(
-                "Acc: {} - Network: {network:?} - Chain: {chain:?} - Using nonce: {correct_nonce}",
-                trim_account(hex::encode(pubkey_bytes)),
-            );
 
             if let Some(fuel_tank_signer_external_id) = fuel_tank_signer_external_id {
                 // expiration block is needed for the signature
@@ -700,11 +689,10 @@ impl TransactionProcessor {
             let encoded_tx = hex::encode(signed_tx.encoded());
 
             tracing::info!(
-                "Request: #{} - Nonce: {} - Extrinsic: 0x{}",
-                request_id,
-                correct_nonce,
-                encoded_tx
+                "Signed #{request_id} nonce={correct_nonce} account=0x{} network={network:?} chain={chain:?}",
+                hex::encode(pubkey_bytes),
             );
+            tracing::debug!("Signed #{request_id} extrinsic: 0x{encoded_tx}",);
             inputs.push(SignTransactionInput {
                 uuid: request_id.clone(),
                 signed_extrinsic: format!("0x{encoded_tx}"),
@@ -761,10 +749,6 @@ impl TransactionProcessor {
     pub fn start(self) -> JoinHandle<()> {
         tokio::spawn(self.launch_job_scheduler())
     }
-}
-
-fn trim_account(account: String) -> String {
-    format!("0x{}...{}", &account[..4], &account[60..])
 }
 
 /// Derive a signer keypair from `keypair` using `external_id` as a soft

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -514,6 +514,11 @@ impl TransactionProcessor {
         }
 
         let mut inputs = Vec::with_capacity(requests.len());
+        // `NonceKey`s whose in-memory counter we advanced during this
+        // batch. On a successful `SignTransactions` round-trip these
+        // increments stay; on failure we evict every entry in this set
+        // (see the `Err` arm after the loop).
+        let mut committed_keys: HashSet<NonceKey> = HashSet::new();
 
         for (signer, request) in signers.into_iter().zip(requests) {
             let TransactionRequest {
@@ -700,10 +705,36 @@ impl TransactionProcessor {
             });
 
             // Only advance the nonce after a tx has been successfully
-            // built, signed, and queued for submission.
+            // built, signed, and queued for submission. Track the
+            // `NonceKey` so we can roll back the in-memory counter if the
+            // batch's `SignTransactions` mutation ultimately fails.
             *nonce_slot += 1;
+            committed_keys.insert(nonce_key);
         }
-        platform_client::sign_transactions(inputs).await;
+
+        // Snapshot the uuids actually queued for submission so we can name
+        // them in the rollback log if the platform mutation fails.
+        let submitted_uuids: Vec<String> = inputs.iter().map(|i| i.uuid.clone()).collect();
+
+        if let Err(e) = platform_client::sign_transactions(inputs).await {
+            // Platform-side failure (after retries): every nonce we
+            // advanced in this batch is uncommitted — those uuids are
+            // still pending on the platform side and the on-chain nonce
+            // hasn't moved. Evict the affected cache entries so the next
+            // batch re-fetches the real on-chain nonce and re-signs the
+            // same uuids at the correct values. Without this, the cache
+            // would drift forward by `committed_keys.len()` entries
+            // relative to chain reality, producing future-nonce
+            // extrinsics on every subsequent batch and a stuck queue.
+            let evicted = evict_nonce_keys(nonces, &committed_keys);
+            let chains: HashSet<ChainKey> = committed_keys
+                .iter()
+                .map(|(net, chain, _)| (*net, *chain))
+                .collect();
+            tracing::error!(
+                "Platform SignTransactions failed; evicting nonce cache for affected chains so the next batch will re-fetch from chain. error={e} chains={chains:?} uuids={submitted_uuids:?} evicted={evicted}",
+            );
+        }
     }
 
     async fn launch_job_scheduler(mut self) {
@@ -775,6 +806,21 @@ fn derive_signer(keypair: &Keypair, external_id: Option<&str>) -> Keypair {
 fn evict_idle_chains(nonces: &mut HashMap<NonceKey, u64>, idle: &HashSet<ChainKey>) -> usize {
     let before = nonces.len();
     nonces.retain(|(net, chain, _), _| !idle.contains(&(*net, *chain)));
+    before - nonces.len()
+}
+
+/// Drop every nonce-cache entry in `keys`. Used to roll back the cache
+/// after a failed `SignTransactions` mutation: the per-tx loop in
+/// `transaction_handler` advances the in-memory nonce counter as each tx
+/// is built and queued for submission, but those increments only reflect
+/// reality once the platform accepts the batch. If the platform-side
+/// mutation ultimately fails (after retries), the cached counters reflect
+/// uncommitted nonces and must be discarded so the next batch re-reads
+/// the on-chain nonce from scratch and re-signs the same uuids at the
+/// correct nonce values. Returns the number of entries actually evicted.
+fn evict_nonce_keys(nonces: &mut HashMap<NonceKey, u64>, keys: &HashSet<NonceKey>) -> usize {
+    let before = nonces.len();
+    nonces.retain(|k, _| !keys.contains(k));
     before - nonces.len()
 }
 
@@ -938,6 +984,62 @@ mod tests {
 
         evict_idle_chains(&mut nonces, &HashSet::new());
 
+        assert_eq!(nonces[&(Network::Enjin, Chain::Matrix, [0u8; 32])], 7);
+        assert_eq!(nonces.len(), 1);
+    }
+
+    /// Rollback-on-failure: when the platform `SignTransactions` mutation
+    /// fails after retries, the in-memory nonce counters that were
+    /// advanced during the failed batch must be evicted (and only those —
+    /// any other keys, including different signers on the same chain,
+    /// must remain intact). The next batch will then re-fetch the real
+    /// on-chain nonce for each evicted key and re-sign the same uuids at
+    /// the correct nonce values.
+    #[test]
+    fn evict_nonce_keys_drops_only_matching_keys() {
+        let mut nonces: HashMap<NonceKey, u64> = HashMap::new();
+
+        let alice = [0xAAu8; 32];
+        let bob = [0xBBu8; 32];
+
+        // Alice was used on Enjin Matrix and Enjin Relay this batch.
+        nonces.insert((Network::Enjin, Chain::Matrix, alice), 31);
+        nonces.insert((Network::Enjin, Chain::Relay, alice), 12);
+        // Bob was on Enjin Matrix this batch but in a *different* tick
+        // that already succeeded; his cache must not be touched.
+        nonces.insert((Network::Enjin, Chain::Matrix, bob), 9);
+        // Alice on Canary was untouched this batch.
+        nonces.insert((Network::Canary, Chain::Matrix, alice), 4);
+
+        // Failed batch advanced Alice on both Enjin chains.
+        let to_evict: HashSet<NonceKey> = [
+            (Network::Enjin, Chain::Matrix, alice),
+            (Network::Enjin, Chain::Relay, alice),
+        ]
+        .into_iter()
+        .collect();
+
+        let evicted = evict_nonce_keys(&mut nonces, &to_evict);
+
+        assert_eq!(evicted, 2);
+        assert!(!nonces.contains_key(&(Network::Enjin, Chain::Matrix, alice)));
+        assert!(!nonces.contains_key(&(Network::Enjin, Chain::Relay, alice)));
+        // Bob on the same chain as Alice must survive.
+        assert_eq!(nonces[&(Network::Enjin, Chain::Matrix, bob)], 9);
+        // Alice on Canary must survive.
+        assert_eq!(nonces[&(Network::Canary, Chain::Matrix, alice)], 4);
+        assert_eq!(nonces.len(), 2);
+    }
+
+    /// A no-op `evict_nonce_keys` call must not touch anything.
+    #[test]
+    fn evict_nonce_keys_empty_set_is_noop() {
+        let mut nonces: HashMap<NonceKey, u64> = HashMap::new();
+        nonces.insert((Network::Enjin, Chain::Matrix, [0u8; 32]), 7);
+
+        let evicted = evict_nonce_keys(&mut nonces, &HashSet::new());
+
+        assert_eq!(evicted, 0);
         assert_eq!(nonces[&(Network::Enjin, Chain::Matrix, [0u8; 32])], 7);
         assert_eq!(nonces.len(), 1);
     }

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -6,13 +6,12 @@ use crate::transaction::fuel_tank::ExpirableSignature;
 use crate::transaction::payload::RawFields;
 use crate::types::{Chain, Network};
 use crate::{DUMMY_TX_MORTALITY, TX_MORTALITY, chain_info, global, platform_client, utils};
-use lru::LruCache;
 use parity_scale_codec::Encode;
 use payload::RawPayload;
-use std::num::NonZeroUsize;
-use std::sync::{Arc, Mutex};
+use std::collections::{HashMap, HashSet};
 use std::time::Duration;
 use subxt::config::DefaultExtrinsicParamsBuilder;
+use subxt::utils::H256;
 use subxt_signer::DeriveJunction;
 use subxt_signer::sr25519::Keypair;
 use tokio::sync::mpsc::{Receiver, Sender};
@@ -23,10 +22,16 @@ const NO_TRANSACTIONS_MSG: &str = "No transactions present in the body";
 const TRANSACTION_POLLER_MS: u64 = 6000;
 const TRANSACTION_PAGE_SIZE: i64 = 25;
 
-/// Cache key for the nonce tracker. Includes `(Network, Chain)` so the same
-/// signing account is tracked independently on every chain it can submit to.
-type NonceCacheKey = (String, Network, Chain);
-type NonceCache = Arc<Mutex<LruCache<NonceCacheKey, u64>>>;
+/// Per-batch nonce map key. Each `(network, chain, signer public key)` tracks
+/// its own counter for the duration of a single batch.
+type NonceKey = (Network, Chain, [u8; 32]);
+
+/// Per-batch chain key for block / metadata prefetch.
+type ChainKey = (Network, Chain);
+
+/// `(block_number, block_hash, spec_version)` captured at prefetch time and
+/// reused for every request signed against that chain in the batch.
+type BlockInfo = (u32, H256, u32);
 
 pub(crate) mod payload {
     use crate::global;
@@ -231,17 +236,115 @@ impl TransactionProcessor {
         Self { keypair, receiver }
     }
 
-    async fn transaction_handler(
-        keypair: Keypair,
-        nonce_tracker: NonceCache,
-        requests: Vec<TransactionRequest>,
-    ) {
+    async fn transaction_handler(keypair: Keypair, requests: Vec<TransactionRequest>) {
+        // Derive the signer for every request up-front so we can both
+        // pre-fetch nonces and reuse the keypair in the main signing loop.
+        let signers: Vec<Keypair> = requests
+            .iter()
+            .map(|r| derive_signer(&keypair, r.external_id.as_deref()))
+            .collect();
+
+        // Pre-fetch per-chain block info and refresh metadata once per
+        // (network, chain) for this batch. If either step fails, the chain is
+        // marked failed and every request targeting it is skipped.
+        let mut block_info: HashMap<ChainKey, BlockInfo> = HashMap::new();
+        let mut failed_chains: HashSet<ChainKey> = HashSet::new();
+        for request in requests.iter() {
+            let key: ChainKey = (request.network, request.chain);
+            if block_info.contains_key(&key) || failed_chains.contains(&key) {
+                continue;
+            }
+
+            let (block_number, block_hash, spec_version) =
+                match chain_info::get_block_and_spec_version(request.network, request.chain).await {
+                    Ok(t) => t,
+                    Err(e) => {
+                        tracing::error!(
+                            "could not fetch block number for {:?}/{:?}: {e}; skipping all requests for this chain in this batch",
+                            request.network,
+                            request.chain,
+                        );
+                        failed_chains.insert(key);
+                        continue;
+                    }
+                };
+
+            let needs_update =
+                match global::metadata_spec_version(request.network, request.chain).await {
+                    Some(local) => local < spec_version,
+                    None => true,
+                };
+            if needs_update
+                && let Err(e) =
+                    chain_info::update_metadata_and_substrate_client(request.network, request.chain)
+                        .await
+            {
+                tracing::error!(
+                    "failed to update metadata for {:?}/{:?}: {e}; skipping all requests for this chain in this batch",
+                    request.network,
+                    request.chain,
+                );
+                failed_chains.insert(key);
+                continue;
+            }
+
+            tracing::info!(
+                "Prefetched block {block_number} (spec {spec_version}) for {:?}/{:?}",
+                request.network,
+                request.chain,
+            );
+            block_info.insert(key, (block_number, block_hash, spec_version));
+        }
+
+        // Pre-fetch the starting nonce once per unique (network, chain, signer)
+        // triple in this batch. We assume the platform's `get_account_nonce`
+        // resolver returns `system_accountNextIndex`.
+        let mut nonces: HashMap<NonceKey, u64> = HashMap::new();
+        let mut failed_keys: HashSet<NonceKey> = HashSet::new();
+        for (signer, request) in signers.iter().zip(requests.iter()) {
+            // Don't bother fetching a nonce for a chain that already failed
+            // its block / metadata prefetch.
+            if failed_chains.contains(&(request.network, request.chain)) {
+                continue;
+            }
+            let key: NonceKey = (request.network, request.chain, signer.public_key().0);
+            if nonces.contains_key(&key) || failed_keys.contains(&key) {
+                continue;
+            }
+            match chain_info::get_account_nonce(
+                request.network,
+                request.chain,
+                &signer.public_key(),
+            )
+            .await
+            {
+                Ok(n) => {
+                    tracing::info!(
+                        "Prefetched nonce {n} for acc {} - Network: {:?} - Chain: {:?}",
+                        trim_account(hex::encode(key.2)),
+                        request.network,
+                        request.chain,
+                    );
+                    nonces.insert(key, n);
+                }
+                Err(e) => {
+                    tracing::error!(
+                        "failed to fetch nonce for {} on {:?}/{:?}: {e}; skipping all requests for this key in this batch",
+                        hex::encode(key.2),
+                        request.network,
+                        request.chain,
+                    );
+                    failed_keys.insert(key);
+                }
+            }
+        }
+
         let mut inputs = Vec::with_capacity(requests.len());
 
-        for request in requests {
+        for (signer, request) in signers.into_iter().zip(requests) {
             let TransactionRequest {
                 request_id,
-                external_id,
+                external_id: _,
                 network,
                 chain,
                 mut payload,
@@ -249,75 +352,51 @@ impl TransactionProcessor {
             } = request;
             tracing::info!("Received transaction request: #{request_id}");
 
-            // get block number
-            let Ok((block_number, block_hash, spec_version)) =
-                chain_info::get_block_and_spec_version(network, chain).await
-            else {
-                tracing::error!("could not fetch block number");
+            let pubkey_bytes = signer.public_key().0;
+            let nonce_key: NonceKey = (network, chain, pubkey_bytes);
+            let chain_key: ChainKey = (network, chain);
+
+            // Skip up-front if the per-chain prefetch failed.
+            if failed_chains.contains(&chain_key) {
+                tracing::error!(
+                    "Skipping request #{request_id}: prefetch failed for {network:?}/{chain:?}"
+                );
                 continue;
-            };
-
-            // check update metadata
-            {
-                let mut update_metadata = false;
-                if let Some(local_spec_version) =
-                    global::metadata_spec_version(network, chain).await
-                {
-                    if local_spec_version < spec_version {
-                        update_metadata = true;
-                    }
-                } else {
-                    update_metadata = true;
-                }
-
-                if update_metadata
-                    && let Err(e) =
-                        chain_info::update_metadata_and_substrate_client(network, chain).await
-                {
-                    tracing::error!("failed to update metadata for {network:?} {chain:?}: {e}");
-                    continue;
-                }
             }
 
-            let signer = if let Some(external_id) = external_id {
-                let derive_junction = match external_id.parse::<i64>() {
-                    Ok(id) => DeriveJunction::soft(id),
-                    Err(_) => DeriveJunction::soft(external_id),
-                };
+            // Skip up-front if the nonce prefetch failed for this key.
+            if failed_keys.contains(&nonce_key) {
+                tracing::error!(
+                    "Skipping request #{request_id}: no prefetched nonce for {}",
+                    hex::encode(pubkey_bytes)
+                );
+                continue;
+            }
 
-                keypair.derive([derive_junction])
-            } else {
-                keypair.clone()
+            let Some(&(block_number, block_hash, _spec_version)) = block_info.get(&chain_key)
+            else {
+                tracing::error!("missing prefetched block info for {network:?}/{chain:?}");
+                continue;
             };
 
             tracing::info!(
                 "Signing transaction #{} with account {}",
                 request_id,
-                hex::encode(signer.public_key().0)
+                hex::encode(pubkey_bytes)
             );
 
-            let public_key = hex::encode(signer.public_key().0);
-            let chain_nonce =
-                match chain_info::get_account_nonce(network, chain, &signer.public_key()).await {
-                    Ok(nonce) => nonce,
-                    Err(e) => {
-                        tracing::error!("failed to fetch nonce for {public_key} with error: {e}");
-                        continue;
-                    }
-                };
-            let correct_nonce: u64;
-            {
-                let mut tracker = nonce_tracker.lock().unwrap();
-                let cache_key = (public_key.clone(), network, chain);
-                let latest_nonce = tracker.get(&cache_key).copied().unwrap_or(0_u64);
-                correct_nonce = compute_next_nonce(latest_nonce, chain_nonce);
-                let acc_format = trim_account(public_key.clone());
-                tracing::info!(
-                    "Acc: {acc_format} - Network: {network:?} - Chain: {chain:?} - Using nonce: {correct_nonce:?} - Cached nonce: {latest_nonce:?} - Metadata nonce: {chain_nonce:?} - Next nonce: {:?}",
-                    correct_nonce + 1
+            let Some(nonce_slot) = nonces.get_mut(&nonce_key) else {
+                tracing::error!(
+                    "missing pre-fetched nonce for {} on {network:?}/{chain:?}",
+                    hex::encode(pubkey_bytes)
                 );
-                tracker.put(cache_key, correct_nonce + 1);
-            }
+                continue;
+            };
+            let correct_nonce = *nonce_slot;
+            tracing::info!(
+                "Acc: {} - Network: {network:?} - Chain: {chain:?} - Using nonce: {correct_nonce}",
+                trim_account(hex::encode(pubkey_bytes)),
+            );
 
             if let Some(fuel_tank_signer_external_id) = fuel_tank_signer_external_id {
                 // expiration block is needed for the signature
@@ -335,21 +414,12 @@ impl TransactionProcessor {
                 };
 
                 // sign by the fuel tank external id if it exists
-                let signer = if let Some(external_id) = fuel_tank_signer_external_id {
-                    let derive_junction = match external_id.parse::<i64>() {
-                        Ok(id) => DeriveJunction::soft(id),
-                        Err(_) => DeriveJunction::soft(external_id),
-                    };
-
-                    keypair.derive([derive_junction])
-                } else {
-                    keypair.clone()
-                };
-                let signature = sp_core::sr25519::Signature::from_raw(signer.sign(&message).0);
+                let ft_signer = derive_signer(&keypair, fuel_tank_signer_external_id.as_deref());
+                let signature = sp_core::sr25519::Signature::from_raw(ft_signer.sign(&message).0);
                 tracing::info!(
                     "fuel tanks - signed message {} with {} and got signature {}",
                     hex::encode(&message),
-                    hex::encode(signer.public_key().0),
+                    hex::encode(ft_signer.public_key().0),
                     hex::encode(signature)
                 );
 
@@ -466,20 +536,21 @@ impl TransactionProcessor {
                 signed_extrinsic: format!("0x{encoded_tx}"),
                 signed_abandon_extrinsic: dummy_tx.clone(),
             });
+
+            // Only advance the nonce after a tx has been successfully
+            // built, signed, and queued for submission.
+            *nonce_slot += 1;
         }
         platform_client::sign_transactions(inputs).await;
     }
 
     async fn launch_job_scheduler(mut self) {
-        let nonce_tracker: NonceCache =
-            Arc::new(Mutex::new(LruCache::new(NonZeroUsize::new(1_000).unwrap())));
-
+        // Process one batch at a time. Awaiting the handler (rather than
+        // `tokio::spawn`ing it) guarantees the previous batch is fully signed
+        // and submitted before the next one starts, which is required for
+        // correct nonce sequencing.
         while let Some(requests) = self.receiver.recv().await {
-            tokio::spawn(Self::transaction_handler(
-                self.keypair.clone(),
-                Arc::clone(&nonce_tracker),
-                requests,
-            ));
+            Self::transaction_handler(self.keypair.clone(), requests).await;
         }
     }
 
@@ -492,86 +563,105 @@ fn trim_account(account: String) -> String {
     format!("0x{}...{}", &account[..4], &account[60..])
 }
 
-/// Select the nonce to use for the next transaction signing, given the last
-/// cached value and the latest on-chain value. Local cache wins when ahead
-/// (catches multiple in-flight txs), the chain wins when ahead (recovers from
-/// daemon restarts or out-of-band txs).
-fn compute_next_nonce(cached_nonce: u64, chain_nonce: u64) -> u64 {
-    cached_nonce.max(chain_nonce)
+/// Derive a signer keypair from `keypair` using `external_id` as a soft
+/// derivation junction. If `external_id` parses as an `i64` the numeric
+/// junction is used; otherwise the raw string is used. When `external_id`
+/// is `None` the root keypair is returned.
+fn derive_signer(keypair: &Keypair, external_id: Option<&str>) -> Keypair {
+    match external_id {
+        Some(id) => {
+            let junction = match id.parse::<i64>() {
+                Ok(n) => DeriveJunction::soft(n),
+                Err(_) => DeriveJunction::soft(id),
+            };
+            keypair.derive([junction])
+        }
+        None => keypair.clone(),
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    /// Regression test for cross-chain nonce bleed.
+    /// Within a single batch, a per-batch `HashMap<NonceKey, u64>` must:
+    ///   * issue strictly consecutive nonces for repeat (network, chain, signer)
+    ///     triples, and
+    ///   * keep counters fully isolated across networks and chains for the
+    ///     same signing account.
     #[test]
-    fn nonce_tracker_isolates_enjin_and_canary_matrix() {
-        let cache: NonceCache =
-            Arc::new(Mutex::new(LruCache::new(NonZeroUsize::new(1_000).unwrap())));
+    fn per_batch_nonce_map_is_consecutive_and_chain_isolated() {
+        let mut nonces: HashMap<NonceKey, u64> = HashMap::new();
 
-        let pubkey = "deadbeef".to_string();
+        let pubkey = [0xABu8; 32];
+        let enjin_matrix: NonceKey = (Network::Enjin, Chain::Matrix, pubkey);
+        let canary_matrix: NonceKey = (Network::Canary, Chain::Matrix, pubkey);
+        let enjin_relay: NonceKey = (Network::Enjin, Chain::Relay, pubkey);
 
-        // Simulate signing 6 txs on Enjin Matrix starting from on-chain nonce 0.
-        // After this, the cache for (pubkey, Enjin, Matrix) should hold 6.
-        {
-            let mut tracker = cache.lock().unwrap();
-            let key = (pubkey.clone(), Network::Enjin, Chain::Matrix);
-            for expected in 0..6u64 {
-                let cached = tracker.get(&key).copied().unwrap_or(0);
-                let chain_nonce = 0u64; // on-chain hasn't caught up yet
-                let used = compute_next_nonce(cached, chain_nonce);
-                assert_eq!(used, expected, "enjin matrix nonce drift");
-                tracker.put(key.clone(), used + 1);
-            }
+        // Simulate prefetch returning chain-side starting nonces.
+        nonces.insert(enjin_matrix, 0);
+        nonces.insert(canary_matrix, 0);
+        nonces.insert(enjin_relay, 0);
+
+        // Sign 6 txs on Enjin Matrix: nonces 0..6, counter ends at 6.
+        for expected in 0..6u64 {
+            let slot = nonces.get_mut(&enjin_matrix).unwrap();
+            assert_eq!(*slot, expected, "enjin matrix not consecutive");
+            *slot += 1;
         }
+        assert_eq!(nonces[&enjin_matrix], 6);
 
-        // Now a tx arrives for the SAME account on Canary Matrix.
-        // Canary's on-chain nonce for this account is 0. Before the fix this
-        // would have signed with nonce 6 (the leaked Enjin value). After the
-        // fix it must sign with 0.
+        // Same account, different network: must still start at 0.
         {
-            let mut tracker = cache.lock().unwrap();
-            let canary_key = (pubkey.clone(), Network::Canary, Chain::Matrix);
-            let cached = tracker.get(&canary_key).copied().unwrap_or(0);
-            assert_eq!(
-                cached, 0,
-                "canary matrix cache must not see enjin matrix nonces"
-            );
-            let used = compute_next_nonce(cached, 0);
-            assert_eq!(used, 0, "canary matrix should start at on-chain nonce 0");
-            tracker.put(canary_key, used + 1);
+            let slot = nonces.get_mut(&canary_matrix).unwrap();
+            assert_eq!(*slot, 0, "canary matrix must not see enjin matrix nonces");
+            *slot += 1;
         }
+        assert_eq!(nonces[&canary_matrix], 1);
+        assert_eq!(nonces[&enjin_matrix], 6, "enjin matrix must be untouched");
 
-        // Enjin Matrix state must be untouched by the Canary write.
+        // Same account, same network, different chain: also independent.
         {
-            let tracker = cache.lock().unwrap();
-            let enjin_key = (pubkey.clone(), Network::Enjin, Chain::Matrix);
-            assert_eq!(tracker.peek(&enjin_key).copied(), Some(6));
+            let slot = nonces.get_mut(&enjin_relay).unwrap();
+            assert_eq!(*slot, 0, "enjin relay must be isolated from enjin matrix");
+            *slot += 1;
         }
-
-        // And Matrix vs. Relay on the same network must also be independent.
-        {
-            let mut tracker = cache.lock().unwrap();
-            let enjin_relay_key = (pubkey.clone(), Network::Enjin, Chain::Relay);
-            let cached = tracker.get(&enjin_relay_key).copied().unwrap_or(0);
-            assert_eq!(cached, 0, "enjin relay must be isolated from enjin matrix");
-            let used = compute_next_nonce(cached, 0);
-            assert_eq!(used, 0);
-            tracker.put(enjin_relay_key, used + 1);
-
-            let enjin_matrix_key = (pubkey, Network::Enjin, Chain::Matrix);
-            assert_eq!(tracker.peek(&enjin_matrix_key).copied(), Some(6));
-        }
+        assert_eq!(nonces[&enjin_relay], 1);
+        assert_eq!(nonces[&enjin_matrix], 6);
     }
 
+    /// A failed sign/build (modeled here as "do not increment the slot")
+    /// must leave the per-batch counter unchanged so the next successful
+    /// request for the same key reuses that nonce. This exercises the
+    /// "increment only on success" property of the new handler.
     #[test]
-    fn compute_next_nonce_prefers_higher_of_cache_or_chain() {
-        // Cache ahead of chain (multiple in-flight txs): trust cache.
-        assert_eq!(compute_next_nonce(5, 2), 5);
-        // Chain ahead of cache (daemon restart or out-of-band tx): trust chain.
-        assert_eq!(compute_next_nonce(2, 5), 5);
-        // Equal: either is fine.
-        assert_eq!(compute_next_nonce(3, 3), 3);
+    fn nonce_slot_is_not_advanced_on_failure() {
+        let mut nonces: HashMap<NonceKey, u64> = HashMap::new();
+        let key: NonceKey = (Network::Enjin, Chain::Matrix, [0u8; 32]);
+        nonces.insert(key, 10);
+
+        // Successful tx: advance.
+        {
+            let slot = nonces.get_mut(&key).unwrap();
+            assert_eq!(*slot, 10);
+            *slot += 1;
+        }
+
+        // Failed tx: do NOT advance (simulates a `continue` in the handler
+        // before the post-push increment).
+        {
+            let slot = nonces.get_mut(&key).unwrap();
+            assert_eq!(*slot, 11);
+            // no `*slot += 1`
+        }
+
+        // Next successful tx reuses 11.
+        {
+            let slot = nonces.get_mut(&key).unwrap();
+            assert_eq!(*slot, 11);
+            *slot += 1;
+        }
+
+        assert_eq!(nonces[&key], 12);
     }
 }

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -15,6 +15,7 @@ use subxt::utils::H256;
 use subxt_signer::DeriveJunction;
 use subxt_signer::sr25519::Keypair;
 use tokio::sync::mpsc::{Receiver, Sender};
+use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
 use tokio::time::sleep;
 
@@ -42,9 +43,19 @@ type BlockInfo = (u32, H256, u32);
 /// batch for those chains re-reads the on-chain nonce from scratch. This
 /// prevents long-term cross-batch nonce desync while letting back-to-back
 /// batches reuse the in-memory counter.
+///
+/// `ack` is a one-shot channel the consumer signals once it has fully
+/// finished processing this tick — including the round-trip to the platform
+/// `SignTransactions` mutation. The producer awaits this ack before issuing
+/// the next `GetPendingTransactions` call. This is the backpressure
+/// mechanism that prevents the producer from racing ahead of the consumer
+/// and re-fetching uuids that are still queued for signing (which would
+/// cause the same uuid to be signed multiple times with consecutive
+/// nonces).
 pub struct ProcessorTick {
     batch: Vec<TransactionRequest>,
     idle: HashSet<ChainKey>,
+    ack: oneshot::Sender<()>,
 }
 
 pub(crate) mod payload {
@@ -165,7 +176,13 @@ impl TransactionJob {
     }
 
     pub fn create_job(keypair: Keypair) -> (TransactionJob, TransactionProcessor) {
-        let (sender, receiver) = tokio::sync::mpsc::channel(50_000);
+        // Capacity 1: combined with `send().await` on the producer side and
+        // a per-tick `oneshot` ack from the consumer, this enforces "at most
+        // one tick in flight at a time." The producer cannot issue a new
+        // `GetPendingTransactions` until the consumer has both pulled the
+        // previous tick AND signaled completion of `SignTransactions` for
+        // it. See `ProcessorTick` for the rationale.
+        let (sender, receiver) = tokio::sync::mpsc::channel(1);
 
         (
             TransactionJob::new(sender),
@@ -188,28 +205,45 @@ impl TransactionJob {
         let mut seen_chains: HashSet<ChainKey> = HashSet::new();
 
         loop {
-            // Only sleep when there is no work to do (or on error). When a
-            // batch was successfully delivered, we immediately poll again to
-            // drain any remaining backlog.
+            // Sleep when there is no work to do (or on error). When a
+            // non-empty batch was successfully delivered, we immediately
+            // re-poll to catch any transactions that were added to the
+            // queue while we were signing the previous batch (signing can
+            // take several seconds; pagination already drained the visible
+            // backlog in a single call, so this re-poll is purely about
+            // picking up newly-arrived work).
+            //
+            // Critically, we await the consumer's ack between sending a
+            // tick and the next poll. Without that, the producer can race
+            // ahead and re-fetch the same uuid multiple times before the
+            // consumer has submitted the corresponding `SignTransactions`
+            // mutation, causing the same uuid to be signed with consecutive
+            // nonces and rejected by the platform.
             let should_sleep = match self.get_pending_transactions().await {
                 Ok(transaction_reqs) => {
-                    let active: HashSet<ChainKey> = transaction_reqs
-                        .iter()
-                        .map(|r| (r.network, r.chain))
-                        .collect();
-                    let idle: HashSet<ChainKey> =
-                        seen_chains.difference(&active).copied().collect();
-                    seen_chains.extend(active.iter().copied());
+                    // Treat an empty `Ok` (e.g. every item on page 1 failed
+                    // `TryFrom`) the same as `NO_TRANSACTIONS_MSG`: back off
+                    // instead of busy-looping on a broken-data condition.
+                    if transaction_reqs.is_empty() {
+                        if !seen_chains.is_empty() {
+                            self.send_tick_and_wait(Vec::new(), seen_chains.clone(), "idle tick")
+                                .await;
+                        }
+                        true
+                    } else {
+                        let active: HashSet<ChainKey> = transaction_reqs
+                            .iter()
+                            .map(|r| (r.network, r.chain))
+                            .collect();
+                        let idle: HashSet<ChainKey> =
+                            seen_chains.difference(&active).copied().collect();
+                        seen_chains.extend(active.iter().copied());
 
-                    let tick = ProcessorTick {
-                        batch: transaction_reqs,
-                        idle,
-                    };
-                    if let Err(e) = self.sender.try_send(tick) {
-                        tracing::info!("Error sending transaction requests: {:?}", e);
+                        self.send_tick_and_wait(transaction_reqs, idle, "transaction requests")
+                            .await;
+                        no_transaction_count = 0;
+                        false
                     }
-                    no_transaction_count = 0;
-                    false
                 }
                 Err(e) => {
                     if e.to_string() == NO_TRANSACTIONS_MSG {
@@ -222,13 +256,8 @@ impl TransactionJob {
                         // tick. Send an empty-batch tick so the consumer can
                         // evict their cache entries.
                         if !seen_chains.is_empty() {
-                            let tick = ProcessorTick {
-                                batch: Vec::new(),
-                                idle: seen_chains.clone(),
-                            };
-                            if let Err(e) = self.sender.try_send(tick) {
-                                tracing::info!("Error sending idle tick: {:?}", e);
-                            }
+                            self.send_tick_and_wait(Vec::new(), seen_chains.clone(), "idle tick")
+                                .await;
                         }
                     } else {
                         tracing::error!("Error: {}", e);
@@ -243,35 +272,116 @@ impl TransactionJob {
         }
     }
 
+    /// Push a `ProcessorTick` into the channel and block until the consumer
+    /// signals it has finished processing it. This is the single
+    /// synchronization point between producer and consumer that prevents
+    /// duplicate signing of the same uuid (see `ProcessorTick` docs and the
+    /// loop comment in `start_polling`).
+    ///
+    /// `kind` is a short label used only in error logs to distinguish the
+    /// three send sites ("transaction requests" vs "idle tick").
+    ///
+    /// Failure modes are logged and swallowed — there is no point bubbling
+    /// them up because the polling loop has nowhere useful to send them and
+    /// must keep running. If `send().await` fails, the consumer task has
+    /// died, in which case the daemon is in a broken state regardless. If
+    /// the ack channel is dropped without being signaled, the consumer
+    /// finished without acknowledging (this should not happen — the
+    /// consumer always sends the ack on the way out of every tick branch);
+    /// log and proceed so the producer can keep polling.
+    async fn send_tick_and_wait(
+        &self,
+        batch: Vec<TransactionRequest>,
+        idle: HashSet<ChainKey>,
+        kind: &str,
+    ) {
+        let (ack_tx, ack_rx) = oneshot::channel();
+        let tick = ProcessorTick {
+            batch,
+            idle,
+            ack: ack_tx,
+        };
+        if let Err(e) = self.sender.send(tick).await {
+            tracing::error!("Failed to send {kind} to processor: {e:?}");
+            return;
+        }
+        if let Err(e) = ack_rx.await {
+            tracing::warn!("Processor dropped ack for {kind} without signaling: {e:?}");
+        }
+    }
+
     async fn get_pending_transactions(
         &self,
     ) -> Result<Vec<TransactionRequest>, Box<dyn std::error::Error + Send + Sync>> {
-        let response_data = utils::execute_query::<GetPendingTransactions>(
-            get_pending_transactions::Variables {
-                limit: TRANSACTION_PAGE_SIZE,
-                cursor: None,
-            },
-            None,
-        )
-        .await?;
+        let mut all: Vec<TransactionRequest> = Vec::new();
+        let mut cursor: Option<String> = None;
+        let mut page_index: usize = 0;
 
-        let transactions_req = response_data.result.ok_or(NO_TRANSACTIONS_MSG)?.data;
+        loop {
+            let response_data = utils::execute_query::<GetPendingTransactions>(
+                get_pending_transactions::Variables {
+                    limit: TRANSACTION_PAGE_SIZE,
+                    cursor: cursor.clone(),
+                },
+                None,
+            )
+            .await?;
 
-        if transactions_req.is_empty() {
-            return Err(NO_TRANSACTIONS_MSG.into());
-        }
+            let result = match response_data.result {
+                Some(r) => r,
+                None => {
+                    // First page: no result at all -> nothing pending.
+                    // Later page: server gave us a `nextCursor` but then
+                    // returned no result; treat as end-of-stream.
+                    if page_index == 0 {
+                        return Err(NO_TRANSACTIONS_MSG.into());
+                    }
+                    break;
+                }
+            };
 
-        Ok(transactions_req
-            .into_iter()
-            .filter_map(|p| {
+            let page = result.data;
+            let next_cursor = result.next_cursor;
+            let page_len = page.len();
+
+            if page_index == 0 && page.is_empty() {
+                return Err(NO_TRANSACTIONS_MSG.into());
+            }
+
+            all.extend(page.into_iter().filter_map(|p| {
                 TransactionRequest::try_from(p)
                     .map_err(|e| {
                         tracing::error!("Error creating TransactionRequest: {}", e);
                         e
                     })
                     .ok()
-            })
-            .collect())
+            }));
+
+            tracing::debug!(
+                "GetPendingTransactions: fetched page {} ({} items, total so far: {}), next_cursor present: {}",
+                page_index,
+                page_len,
+                all.len(),
+                next_cursor.is_some(),
+            );
+
+            page_index += 1;
+
+            match next_cursor {
+                Some(c) if !c.is_empty() => cursor = Some(c),
+                _ => break,
+            }
+        }
+
+        if page_index > 1 {
+            tracing::info!(
+                "GetPendingTransactions: drained {} pages, {} transaction(s) total",
+                page_index,
+                all.len(),
+            );
+        }
+
+        Ok(all)
     }
 }
 
@@ -613,7 +723,14 @@ impl TransactionProcessor {
         // `tokio::spawn`ing it) guarantees the previous batch is fully signed
         // and submitted before the next one starts, which is required for
         // correct nonce sequencing.
-        while let Some(ProcessorTick { batch, idle }) = self.receiver.recv().await {
+        //
+        // After processing each tick — including any `SignTransactions`
+        // round-trip in `transaction_handler` — we signal the producer via
+        // the per-tick `ack` channel. The producer blocks on this ack
+        // before issuing the next `GetPendingTransactions`, which is what
+        // prevents the producer from racing ahead and re-fetching uuids
+        // that are still queued for signing.
+        while let Some(ProcessorTick { batch, idle, ack }) = self.receiver.recv().await {
             // Apply idle resets BEFORE processing the batch. By construction
             // the poller never includes a chain in both `batch` and `idle` for
             // the same tick, but applying resets first keeps semantics
@@ -632,6 +749,12 @@ impl TransactionProcessor {
             if !batch.is_empty() {
                 Self::transaction_handler(self.keypair.clone(), &mut self.nonces, batch).await;
             }
+
+            // Always signal the producer, even on an empty batch (idle
+            // ticks still need an ack to release the producer). Failure
+            // here means the producer has already gone away, which would
+            // mean the daemon is shutting down — nothing actionable.
+            let _ = ack.send(());
         }
     }
 


### PR DESCRIPTION
- nonce and chain info are fetched once at the beginning of each tx batch
- cached nonces are reset when no pending txs are received for a chain
- delete cached nonce if submission to platform fails
- processing pending transactions is now fully synchronous
- cursor is now used when fetching txs
- only sleep if there is no pending work
- consolidated log messages
- bump version to `3.0.5`