### PR TITLE
[PLA-2450] Read .env file saved by powershell

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5097,7 +5097,7 @@ dependencies = [
 
 [[package]]
 name = "wallet-daemon"
-version = "3.0.7"
+version = "3.0.8"
 dependencies = [
  "aes-gcm",
  "argon2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wallet-daemon"
-version = "3.0.7"
+version = "3.0.8"
 edition = "2024"
 
 [[bin]]

--- a/README.md
+++ b/README.md
@@ -37,6 +37,27 @@ KEY_PASS=your-unique-key-password
 PLATFORM_KEY=your-platform-api-token
 ```
 
+### Windows / PowerShell
+
+The `.env` file must be UTF-8. Windows PowerShell 5.1 writes UTF-16 by default
+(`>`, `Out-File`, `Set-Content` without `-Encoding`), which can corrupt `.env`.
+The daemon auto-detects and reads UTF-16 `.env` files, but to be safe either
+save explicitly as UTF-8:
+
+```powershell
+Set-Content -Path .env -Encoding utf8 -Value "KEY_PASS=...`nPLATFORM_KEY=..."
+```
+
+or set the variables in the session instead of using a file:
+
+```powershell
+$env:KEY_PASS="your-unique-key-password"
+$env:PLATFORM_KEY="your-platform-api-token"
+```
+
+Also make sure the file is named exactly `.env`, not `.env.txt` (Notepad can add
+a hidden `.txt` extension).
+
 ## Running Locally
 
 Build and run from source:

--- a/src/env_loader.rs
+++ b/src/env_loader.rs
@@ -42,7 +42,13 @@ pub fn load_env() {
 /// Walks up from the current directory looking for a `.env` file, mirroring
 /// dotenvy's default lookup so behavior is unchanged for UTF-8 users.
 fn find_dotenv() -> Option<PathBuf> {
-    let mut dir: PathBuf = std::env::current_dir().ok()?;
+    find_dotenv_from(std::env::current_dir().ok()?)
+}
+
+/// Walks up from `start` looking for a `.env` file. Pure — touches no process
+/// state — so it can be tested directly without `set_current_dir`.
+fn find_dotenv_from(start: PathBuf) -> Option<PathBuf> {
+    let mut dir = start;
     loop {
         let candidate = dir.join(".env");
         if candidate.is_file() {
@@ -55,14 +61,18 @@ fn find_dotenv() -> Option<PathBuf> {
 }
 
 fn decode_utf16(body: &[u8], to_u16: fn([u8; 2]) -> u16) -> String {
-    let units: Vec<u16> = body.chunks_exact(2).map(|c| to_u16([c[0], c[1]])).collect();
+    let mut units: Vec<u16> = body.chunks_exact(2).map(|c| to_u16([c[0], c[1]])).collect();
+    // An odd trailing byte means the file is truncated or not actually UTF-16.
+    // Preserve it as U+FFFD rather than silently dropping data.
+    if !body.len().is_multiple_of(2) {
+        units.push(0xFFFD);
+    }
     String::from_utf16_lossy(&units)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::path::Path;
 
     fn read_back(bytes: &[u8]) -> String {
         // Reproduce load_env's transcoding without touching process env.
@@ -126,8 +136,40 @@ mod tests {
     }
 
     #[test]
-    fn find_dotenv_returns_none_when_absent() {
-        // Sanity: a path that cannot exist as a file.
-        assert!(!Path::new("/nonexistent-dir-xyz/.env").is_file());
+    fn decodes_odd_length_utf16_with_replacement() {
+        // "AB" as UTF-16 LE plus a dangling odd byte after the BOM.
+        let mut bytes = vec![0xFF, 0xFE];
+        bytes.extend("AB".encode_utf16().flat_map(u16::to_le_bytes));
+        bytes.push(0x00); // truncated final code unit
+        let out = read_back(&bytes);
+        assert!(out.starts_with("AB"), "decoded prefix lost: {out:?}");
+        assert!(
+            out.ends_with('\u{FFFD}'),
+            "dangling byte should become U+FFFD, got {out:?}"
+        );
+    }
+
+    #[test]
+    fn find_dotenv_walks_up_to_ancestor() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join(".env"), b"KEY_PASS=x\n").unwrap();
+        let nested = root.path().join("a/b");
+        std::fs::create_dir_all(&nested).unwrap();
+
+        assert_eq!(find_dotenv_from(nested), Some(root.path().join(".env")));
+    }
+
+    #[test]
+    fn find_dotenv_prefers_nearest() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join(".env"), b"a=1\n").unwrap();
+        let nearer = root.path().join("a");
+        std::fs::create_dir_all(nearer.join("b")).unwrap();
+        std::fs::write(nearer.join(".env"), b"a=2\n").unwrap();
+
+        assert_eq!(
+            find_dotenv_from(root.path().join("a/b")),
+            Some(nearer.join(".env"))
+        );
     }
 }

--- a/src/env_loader.rs
+++ b/src/env_loader.rs
@@ -55,10 +55,7 @@ fn find_dotenv() -> Option<PathBuf> {
 }
 
 fn decode_utf16(body: &[u8], to_u16: fn([u8; 2]) -> u16) -> String {
-    let units: Vec<u16> = body
-        .chunks_exact(2)
-        .map(|c| to_u16([c[0], c[1]]))
-        .collect();
+    let units: Vec<u16> = body.chunks_exact(2).map(|c| to_u16([c[0], c[1]])).collect();
     String::from_utf16_lossy(&units)
 }
 

--- a/src/env_loader.rs
+++ b/src/env_loader.rs
@@ -1,0 +1,136 @@
+//! Loads the `.env` file with tolerance for UTF-16 encodings.
+//!
+//! `dotenvy` only understands UTF-8 (it strips a UTF-8 BOM but nothing else).
+//! Windows PowerShell 5.1 writes files as UTF-16 LE with a BOM by default
+//! (`>`, `Out-File`, `Set-Content`, `Add-Content` without `-Encoding`), so a
+//! `.env` created that way is unreadable and the daemon exits complaining that
+//! required variables are missing. We detect a UTF-16 BOM, transcode to UTF-8,
+//! and hand the result to dotenvy. UTF-8 files take dotenvy's normal path.
+
+use std::io::Cursor;
+use std::path::PathBuf;
+
+/// Finds and loads `.env`, transcoding UTF-16 (LE/BE) to UTF-8 when needed.
+///
+/// Must be called before the first `dotenvy::var` access. dotenvy does not
+/// override variables that are already set, so values we load here win over
+/// dotenvy's later lazy load of the same file.
+pub fn load_env() {
+    let Some(path) = find_dotenv() else {
+        // No `.env` found; rely on real environment variables.
+        return;
+    };
+
+    let Ok(bytes) = std::fs::read(&path) else {
+        return;
+    };
+
+    let text = if bytes.starts_with(&[0xFF, 0xFE]) {
+        decode_utf16(&bytes[2..], u16::from_le_bytes)
+    } else if bytes.starts_with(&[0xFE, 0xFF]) {
+        decode_utf16(&bytes[2..], u16::from_be_bytes)
+    } else {
+        // UTF-8 (with or without BOM): let dotenvy handle it from the path so
+        // its own BOM stripping and parsing apply unchanged.
+        let _ = dotenvy::from_path(&path);
+        return;
+    };
+
+    let _ = dotenvy::from_read(Cursor::new(text.into_bytes()));
+}
+
+/// Walks up from the current directory looking for a `.env` file, mirroring
+/// dotenvy's default lookup so behavior is unchanged for UTF-8 users.
+fn find_dotenv() -> Option<PathBuf> {
+    let mut dir: PathBuf = std::env::current_dir().ok()?;
+    loop {
+        let candidate = dir.join(".env");
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+        if !dir.pop() {
+            return None;
+        }
+    }
+}
+
+fn decode_utf16(body: &[u8], to_u16: fn([u8; 2]) -> u16) -> String {
+    let units: Vec<u16> = body
+        .chunks_exact(2)
+        .map(|c| to_u16([c[0], c[1]]))
+        .collect();
+    String::from_utf16_lossy(&units)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    fn read_back(bytes: &[u8]) -> String {
+        // Reproduce load_env's transcoding without touching process env.
+        if bytes.starts_with(&[0xFF, 0xFE]) {
+            decode_utf16(&bytes[2..], u16::from_le_bytes)
+        } else if bytes.starts_with(&[0xFE, 0xFF]) {
+            decode_utf16(&bytes[2..], u16::from_be_bytes)
+        } else {
+            String::from_utf8_lossy(bytes).into_owned()
+        }
+    }
+
+    fn utf16_le_bom(s: &str) -> Vec<u8> {
+        let mut out = vec![0xFF, 0xFE];
+        for u in s.encode_utf16() {
+            out.extend_from_slice(&u.to_le_bytes());
+        }
+        out
+    }
+
+    fn utf16_be_bom(s: &str) -> Vec<u8> {
+        let mut out = vec![0xFE, 0xFF];
+        for u in s.encode_utf16() {
+            out.extend_from_slice(&u.to_be_bytes());
+        }
+        out
+    }
+
+    #[test]
+    fn decodes_utf16_le_with_bom() {
+        let src = "KEY_PASS=hunter2\nPLATFORM_KEY=token\n";
+        assert_eq!(read_back(&utf16_le_bom(src)), src);
+    }
+
+    #[test]
+    fn decodes_utf16_be_with_bom() {
+        let src = "KEY_PASS=hunter2\nPLATFORM_KEY=token\n";
+        assert_eq!(read_back(&utf16_be_bom(src)), src);
+    }
+
+    #[test]
+    fn passes_utf8_through_unchanged() {
+        let src = "KEY_PASS=hunter2\n";
+        assert_eq!(read_back(src.as_bytes()), src);
+    }
+
+    #[test]
+    fn transcoded_utf16_parses_as_env_pairs() {
+        let src = "KEY_PASS=hunter2\nPLATFORM_KEY=token\n";
+        let text = read_back(&utf16_le_bom(src));
+        let pairs: Vec<(String, String)> = dotenvy::from_read_iter(Cursor::new(text.into_bytes()))
+            .map(|item| item.expect("valid env pair"))
+            .collect();
+        assert_eq!(
+            pairs,
+            vec![
+                ("KEY_PASS".to_string(), "hunter2".to_string()),
+                ("PLATFORM_KEY".to_string(), "token".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn find_dotenv_returns_none_when_absent() {
+        // Sanity: a path that cannot exist as a file.
+        assert!(!Path::new("/nonexistent-dir-xyz/.env").is_file());
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,7 @@ pub const DUMMY_TX_MORTALITY: u64 = 14_400;
 
 mod chain_info;
 mod crypto;
+mod env_loader;
 mod global;
 mod graphql;
 mod importer;
@@ -36,6 +37,9 @@ mod wallet_loader;
 
 #[tokio::main(flavor = "multi_thread")]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Load `.env` (transcoding UTF-16 to UTF-8) before any `dotenvy::var` call.
+    env_loader::load_env();
+
     let seed_path = resolve_seed_path(dotenvy::var("SEED_PATH").ok().as_deref());
 
     // check for subcommands


### PR DESCRIPTION
## Summary

Makes the daemon tolerant of UTF-16-encoded `.env` files, which Windows
PowerShell produces by default. Previously a `.env` created in PowerShell would
be silently unreadable, and the daemon would exit with
`KEY_PASS env var is required` even though the file looked correct.

Also bumps version to `v3.0.8`

## Background

The daemon loads configuration via the `dotenvy` crate. `dotenvy` only parses
UTF-8 (it strips a UTF-8 BOM but nothing else). Windows PowerShell 5.1 — the
default `powershell.exe` on Windows — writes files as **UTF-16 LE with a BOM**
when using `>`, `Out-File`, `Set-Content`, or `Add-Content` without an explicit
`-Encoding`. A `.env` created that way is read as garbage bytes, no variables
are found, and the daemon dies on the first required variable.

The encoding is invisible in most editors, so the file looks fine and the error
message (`KEY_PASS env var is required`) points users in the wrong direction.
This is a `.env`-format convention issue, not a `dotenvy` bug — no mainstream
dotenv library decodes UTF-16 — so we handle it in the daemon.

## Changes

- **`src/env_loader.rs` (new):** `load_env()` locates `.env` (walking up parent
  directories, mirroring dotenvy's default lookup), detects a UTF-16 LE/BE BOM,
  transcodes the contents to UTF-8, and feeds them to `dotenvy::from_read`.
  UTF-8 files (with or without a BOM) fall through to dotenvy's normal
  `from_path` load, so existing behavior is unchanged.
- **`src/main.rs`:** calls `env_loader::load_env()` as the first line of
  `main()`, before any `dotenvy::var` access. dotenvy does not override
  already-set variables, so the transcoded values take precedence over its
  later lazy load of the same file.
- **`README.md`:** adds a Windows / PowerShell note covering the UTF-8
  requirement, the `Set-Content -Encoding utf8` and `$env:` alternatives, and
  the `.env.txt` filename trap.

## Testing

- Unit tests in `env_loader` cover UTF-16 LE, UTF-16 BE, UTF-8 passthrough,
  and end-to-end parsing of transcoded content into env pairs:
  `cargo test --bin wallet-daemon env_loader`.
- Verified end-to-end on macOS by generating a genuine UTF-16 LE `.env`
  (the exact byte pattern PowerShell writes) and running the binary against it:
  - **Before:** `panicked: KEY_PASS env var is required: EnvVar(NotPresent)`
  - **After:** `KEY_PASS` is read and the daemon proceeds normally.

## Limitations

- Only auto-detects UTF-16 files that carry a BOM (which is what PowerShell
  produces). BOM-less UTF-16 cannot be reliably detected and is not handled, by
  design.
- The transcoding is silent. An alternative would be to detect UTF-16 and emit
  an explicit "re-save as UTF-8" error instead; we chose to absorb it
  transparently for end-user convenience.